### PR TITLE
Splitting improvements

### DIFF
--- a/AuroraEditor/Base/NavigatorSidebar/UI/NavigatorSidebar.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/UI/NavigatorSidebar.swift
@@ -67,7 +67,8 @@ struct NavigatorSidebar: View {
         }
         .splitView(availablePositions: [.top, .bottom, .center],
                    proposalPosition: $dropProposal,
-                   margin: 15,
+                   margin: 0.25,
+                   isProportional: true,
                    onDrop: { position in
             switch position {
             case .top:

--- a/AuroraEditor/Utils/SplitView/DropProposalPositionCalculations.swift
+++ b/AuroraEditor/Utils/SplitView/DropProposalPositionCalculations.swift
@@ -74,33 +74,36 @@ import Foundation
  */
 func calculateDropProposalPosition(in rect: CGRect,
                                    for point: CGPoint,
-                                   margin: CGFloat) -> SplitViewProposalDropPosition? {
+                                   margin: CGFloat,
+                                   hitboxSizes: [SplitViewProposalDropPosition: CGFloat] = [:],
+                                   availablePositions: [SplitViewProposalDropPosition] = []
+) -> SplitViewProposalDropPosition? {
     let leadingRect = CGRect(
         x: rect.minX,
         y: rect.minY,
-        width: margin,
+        width: availablePositions.contains(.leading) ? (hitboxSizes[.leading] ?? margin) : 0,
         height: rect.height
     )
 
     let trailingRect = CGRect(
-        x: rect.maxX - margin,
+        x: rect.maxX - (availablePositions.contains(.trailing) ? (hitboxSizes[.trailing] ?? margin) : 0),
         y: rect.minY,
-        width: margin,
+        width: availablePositions.contains(.trailing) ? (hitboxSizes[.trailing] ?? margin) : 0,
         height: rect.height
     )
 
     let topRect = CGRect(
-        x: rect.minX + margin,
+        x: leadingRect.maxX,
         y: rect.minY,
-        width: rect.width - 2 * margin,
-        height: margin
+        width: rect.width - leadingRect.width - trailingRect.width,
+        height: availablePositions.contains(.top) ? (hitboxSizes[.top] ?? margin) : 0
     )
 
     let bottomRect = CGRect(
-        x: rect.minX + margin,
-        y: rect.maxY - margin,
-        width: rect.width - 2 * margin,
-        height: margin
+        x: leadingRect.maxX,
+        y: rect.maxY - (availablePositions.contains(.bottom) ? (hitboxSizes[.bottom] ?? margin) : 0),
+        width: rect.width - leadingRect.width - trailingRect.width,
+        height: availablePositions.contains(.top) ? (hitboxSizes[.bottom] ?? margin) : 0
     )
 
     if leadingRect.contains(point) {

--- a/AuroraEditor/Utils/SplitView/SplitViewDropDelegate.swift
+++ b/AuroraEditor/Utils/SplitView/SplitViewDropDelegate.swift
@@ -15,6 +15,7 @@ struct SplitViewDropDelegate: DropDelegate {
     let availablePositions: [SplitViewProposalDropPosition]
     let geometryProxy: GeometryProxy
     let margin: CGFloat
+    let hitboxSizes: [SplitViewProposalDropPosition: CGFloat]
     let onDrop: ((SplitViewProposalDropPosition) -> Void)?
 
     func performDrop(info: DropInfo) -> Bool {
@@ -31,7 +32,9 @@ struct SplitViewDropDelegate: DropDelegate {
         if let calculatedProposalPosition = calculateDropProposalPosition(
             in: localFrame,
             for: info.location,
-            margin: margin
+            margin: margin,
+            hitboxSizes: hitboxSizes,
+            availablePositions: availablePositions
         ), availablePositions.contains(calculatedProposalPosition) {
             proposalPosition = calculatedProposalPosition
         } else {

--- a/AuroraEditor/Utils/SplitView/SplitViewDropProposalOverlay.swift
+++ b/AuroraEditor/Utils/SplitView/SplitViewDropProposalOverlay.swift
@@ -36,17 +36,23 @@ struct SplitViewDropProposalOverlay: View {
 
     @ViewBuilder
     private var contentView: some View {
-        switch proposalPosition {
-        case .leading:
-            leadingPositionOverlay
-        case .trailing:
-            trailingPositionOverlay
-        case .top:
-            topPositionOverlay
-        case .bottom:
-            bottomPositionOverlay
-        case .center:
-            centerPositionOverlay
+        ZStack {
+            if let proposalPosition = proposalPosition {
+                switch proposalPosition {
+                case .leading:
+                    leadingPositionOverlay
+                case .trailing:
+                    trailingPositionOverlay
+                case .top:
+                    topPositionOverlay
+                case .bottom:
+                    bottomPositionOverlay
+                case .center:
+                    centerPositionOverlay
+                }
+            } else {
+                noPositionOverlay
+            }
         }
     }
 
@@ -80,6 +86,11 @@ struct SplitViewDropProposalOverlay: View {
 
     private var centerPositionOverlay: some View {
         overlay
+    }
+
+    private var noPositionOverlay: some View {
+        overlay
+            .frame(width: 0, height: 0)
     }
 
     private var overlay: some View {

--- a/AuroraEditor/Utils/SplitView/SplitViewDropProposalOverlay.swift
+++ b/AuroraEditor/Utils/SplitView/SplitViewDropProposalOverlay.swift
@@ -23,7 +23,7 @@ struct SplitViewDropProposalOverlay: View {
 
     @Namespace private var animation
 
-    let proposalPosition: SplitViewProposalDropPosition
+    let proposalPosition: SplitViewProposalDropPosition?
 
     var body: some View {
         contentView

--- a/AuroraEditor/Utils/SplitView/SplitViewModifier.swift
+++ b/AuroraEditor/Utils/SplitView/SplitViewModifier.swift
@@ -33,11 +33,10 @@ struct SplitViewModifier: ViewModifier {
                         )
                     )
 
-                if let proposalPosition = proposalPosition {
-                    SplitViewDropProposalOverlay(
-                        proposalPosition: proposalPosition
-                    )
-                }
+                SplitViewDropProposalOverlay(
+                    proposalPosition: proposalPosition
+                )
+                .opacity(proposalPosition == nil ? 0 : 1)
             }
         }
     }

--- a/AuroraEditor/Utils/SplitView/SplitViewModifier.swift
+++ b/AuroraEditor/Utils/SplitView/SplitViewModifier.swift
@@ -13,6 +13,8 @@ struct SplitViewModifier: ViewModifier {
 
     let availablePositions: [SplitViewProposalDropPosition]
     let margin: CGFloat
+    let isProportional: Bool
+    let hitboxSizes: [SplitViewProposalDropPosition: CGFloat]
     let onDrop: ((SplitViewProposalDropPosition) -> Void)?
 
     func body(content: Content) -> some View {
@@ -26,6 +28,7 @@ struct SplitViewModifier: ViewModifier {
                             availablePositions: availablePositions,
                             geometryProxy: geometryProxy,
                             margin: margin,
+                            hitboxSizes: isProportional ? getHitboxSizes(geometryProxy: geometryProxy) : hitboxSizes,
                             onDrop: onDrop
                         )
                     )
@@ -38,6 +41,16 @@ struct SplitViewModifier: ViewModifier {
             }
         }
     }
+
+    func getHitboxSizes(geometryProxy: GeometryProxy) -> [SplitViewProposalDropPosition: CGFloat] {
+        let localFrame = geometryProxy.frame(in: .local)
+        return [
+            .top: localFrame.height * (hitboxSizes[.top] ?? margin),
+            .bottom: localFrame.height * (hitboxSizes[.bottom] ?? margin),
+            .leading: localFrame.width * (hitboxSizes[.leading] ?? margin),
+            .trailing: localFrame.width * (hitboxSizes[.trailing] ?? margin)
+        ]
+    }
 }
 
 extension View {
@@ -47,16 +60,21 @@ extension View {
     ///   - availablePositions: availablePositions description
     ///   - proposalPosition: proposalPosition description
     ///   - margin: margin description
+    ///   - isProportional: If true, the `margin` is used as a percentage of the frame for the dragging hitbox
     ///   - onDrop: onDrop description
     ///
     /// - Returns: description
     public func splitView(availablePositions: [SplitViewProposalDropPosition],
                           proposalPosition: Binding<SplitViewProposalDropPosition?>,
                           margin: CGFloat,
+                          isProportional: Bool = false,
+                          hitboxSizes: [SplitViewProposalDropPosition: CGFloat] = [:],
                           onDrop: ((SplitViewProposalDropPosition) -> Void)?) -> some View {
         modifier(SplitViewModifier(proposalPosition: proposalPosition,
                                    availablePositions: availablePositions,
                                    margin: margin,
+                                   isProportional: isProportional,
+                                   hitboxSizes: hitboxSizes,
                                    onDrop: onDrop))
     }
 }


### PR DESCRIPTION
# Description

Added 
- relative hitbox sizes, so now hitboxes grow with the view
- disabling certain hitboxes now allows the other hitboxes to fill up the space
- added an appearing/disappearing animation, now the overlay grows from the centre when it appears and disappears instead of doing it suddenly.

# Related Issue

none

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/AuroraEditor/AuroraEditor/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/AuroraEditor/AuroraEditor/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

can't screenshot this 😢 but you'll notice that the animations and hitboxes should be smoother, especially in the navigation sidebar where i implemented most of the changes. 
