### PR TITLE
Fix some UI issues

### DIFF
--- a/AuroraEditor/Base/AuroraEditorTextView/UI/STTextViewController.swift
+++ b/AuroraEditor/Base/AuroraEditorTextView/UI/STTextViewController.swift
@@ -63,6 +63,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate {
     }
 
     // MARK: VC Lifecycle
+    // swiftlint:disable:next function_body_length
     override public func loadView() {
         let scrollView = STTextView.scrollableTextView()
         textView = scrollView.documentView as? STTextView
@@ -81,7 +82,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate {
 
         textView.defaultParagraphStyle = self.paragraphStyle
         textView.font = NSFont.monospacedSystemFont(
-            ofSize: 10,
+            ofSize: 12,
             weight: .medium
         )
         textView.textColor = .textColor
@@ -92,6 +93,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate {
 
         textView.widthTracksTextView = true
         textView.highlightSelectedLine = true
+        textView.selectedLineHighlightColor = selectedLineHighlightColor()
         textView.allowsUndo = true
         textView.setupMenus()
         textView.delegate = self
@@ -152,6 +154,7 @@ public class STTextViewController: NSViewController, STTextViewDelegate {
         textView?.font = font
         textView?.textColor = .textColor
         textView?.backgroundColor = textViewBackgroundColor()
+        textView?.selectedLineHighlightColor = selectedLineHighlightColor()
 //        textView?.insertionPointColor = theme.insertionPoint
 //        textView?.selectionBackgroundColor = theme.selection
 //        textView?.selectedLineHighlightColor = theme.lineHighlight
@@ -210,5 +213,12 @@ public class STTextViewController: NSViewController, STTextViewDelegate {
             return .textBackgroundColor
         }
         return NSColor(hex: currentTheme.editor.background.color)
+    }
+
+    private func selectedLineHighlightColor() -> NSColor {
+        guard let currentTheme = ThemeModel.shared.selectedTheme else {
+            return NSColor.selectedTextBackgroundColor.withAlphaComponent(0.25)
+        }
+        return NSColor(hex: currentTheme.editor.lineHighlight.color)
     }
 }

--- a/AuroraEditor/Base/InspectorSidebar/UI/FileInspector/FileInspectorView.swift
+++ b/AuroraEditor/Base/InspectorSidebar/UI/FileInspector/FileInspectorView.swift
@@ -39,7 +39,7 @@ struct FileInspectorView: View {
                     Text("Identity and Type")
                         .foregroundColor(.secondary)
                         .fontWeight(.bold)
-                        .font(.system(size: 11))
+                        .font(.system(size: 13))
 
                     Spacer()
 
@@ -47,7 +47,6 @@ struct FileInspectorView: View {
                         Text(hideidentityType ? "Hide" : "Show")
                             .foregroundColor(.secondary)
                             .fontWeight(.bold)
-                            .font(.system(size: 11))
                             .onTapGesture {
                                 hideidentityType.toggle()
                             }
@@ -61,7 +60,7 @@ struct FileInspectorView: View {
                                 Text("Name")
                                     .foregroundColor(.primary)
                                     .fontWeight(.regular)
-                                    .font(.system(size: 11))
+                                    .font(.system(size: 10))
                                 TextField("", text: $inspectorModel.fileName)
                                     .font(.system(size: 11))
                                     .frame(maxWidth: 150)
@@ -74,7 +73,7 @@ struct FileInspectorView: View {
                                 Text("Type")
                                     .foregroundColor(.primary)
                                     .fontWeight(.regular)
-                                    .font(.system(size: 11))
+                                    .font(.system(size: 10))
                                 fileType
                             }
 
@@ -86,7 +85,7 @@ struct FileInspectorView: View {
                                 Text("Location")
                                     .foregroundColor(.primary)
                                     .fontWeight(.regular)
-                                    .font(.system(size: 11))
+                                    .font(.system(size: 10))
 
                                 VStack {
                                     location
@@ -109,13 +108,13 @@ struct FileInspectorView: View {
                                 Text("Full Path")
                                     .foregroundColor(.primary)
                                     .fontWeight(.regular)
-                                    .font(.system(size: 11))
+                                    .font(.system(size: 10))
 
                                 HStack(alignment: .bottom) {
                                     Text(inspectorModel.fileURL)
                                         .foregroundColor(.primary)
                                         .fontWeight(.regular)
-                                        .font(.system(size: 11))
+                                        .font(.system(size: 10))
                                         .lineLimit(4)
 
                                     Image(systemName: "arrow.forward.circle.fill")
@@ -161,7 +160,6 @@ struct FileInspectorView: View {
                         Text(hideTextSettings ? "Hide" : "Show")
                             .foregroundColor(.secondary)
                             .fontWeight(.bold)
-                            .font(.system(size: 11))
                             .onTapGesture {
                                 hideTextSettings.toggle()
                             }
@@ -174,7 +172,7 @@ struct FileInspectorView: View {
                             Text("Text Encoding")
                                 .foregroundColor(.primary)
                                 .fontWeight(.regular)
-                                .font(.system(size: 11))
+                                .font(.system(size: 10))
                             textEncoding
                         }
 
@@ -182,7 +180,7 @@ struct FileInspectorView: View {
                             Text("Line Endings")
                                 .foregroundColor(.primary)
                                 .fontWeight(.regular)
-                                .font(.system(size: 11))
+                                .font(.system(size: 10))
                             lineEndings
                         }
                         .padding(.top, 4)
@@ -193,7 +191,7 @@ struct FileInspectorView: View {
                             Text("Indent Using")
                                 .foregroundColor(.primary)
                                 .fontWeight(.regular)
-                                .font(.system(size: 11))
+                                .font(.system(size: 10))
                             indentUsing
                         }
                         .padding(.top, 1)
@@ -205,6 +203,7 @@ struct FileInspectorView: View {
             }
 
             Divider()
+
         }.frame(maxWidth: 250).padding(5)
     }
 
@@ -214,53 +213,63 @@ struct FileInspectorView: View {
                 Section(header: Text("Sourcecode Objective-C")) {
                     ForEach(inspectorModel.languageTypeObjCList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Sourcecode C")) {
                     ForEach(inspectorModel.sourcecodeCList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Sourcecode C++")) {
                     ForEach(inspectorModel.sourcecodeCPlusList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Sourcecode Swift")) {
                     ForEach(inspectorModel.sourcecodeSwiftList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Sourcecode Assembly")) {
                     ForEach(inspectorModel.sourcecodeAssemblyList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
             }
             Group {
-                Section(header: Text("Sourcecode Script")) {
+                Section(header: Text("Sourcecode Objective-C")) {
                     ForEach(inspectorModel.sourcecodeScriptList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Property List / XML")) {
                     ForEach(inspectorModel.propertyList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Shell Script")) {
                     ForEach(inspectorModel.shellList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Mach-O")) {
                     ForEach(inspectorModel.machOList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Text")) {
                     ForEach(inspectorModel.textList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
             }
@@ -268,72 +277,82 @@ struct FileInspectorView: View {
                 Section(header: Text("Audio")) {
                     ForEach(inspectorModel.audioList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Image")) {
                     ForEach(inspectorModel.imageList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Video")) {
                     ForEach(inspectorModel.videoList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Archive")) {
                     ForEach(inspectorModel.archiveList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
                 Section(header: Text("Other")) {
                     ForEach(inspectorModel.otherList) {
                         Text($0.name)
+                            .font(.system(size: 11))
                     }
                 }
             }
         }
         .labelsHidden()
-        .modifier(CustomPickerView())
+        .frame(maxWidth: 150, maxHeight: 12)
     }
 
     private var location: some View {
         Picker("", selection: $inspectorModel.locationSelection) {
             ForEach(inspectorModel.locationList) {
                 Text($0.name)
+                    .font(.system(size: 11))
             }
         }
         .labelsHidden()
-        .modifier(CustomPickerView())
+        .frame(maxWidth: 150, maxHeight: 12)
     }
 
     private var textEncoding: some View {
         Picker("", selection: $inspectorModel.textEncodingSelection) {
             ForEach(inspectorModel.textEncodingList) {
                 Text($0.name)
+                    .font(.system(size: 11))
             }
         }
         .labelsHidden()
-        .modifier(CustomPickerView())
+        .frame(maxWidth: 150, maxHeight: 12)
     }
 
     private var lineEndings: some View {
         Picker("", selection: $inspectorModel.lineEndingsSelection) {
             ForEach(inspectorModel.lineEndingsList) {
                 Text($0.name)
+                    .font(.system(size: 11))
             }
         }
         .labelsHidden()
-        .modifier(CustomPickerView())
+        .frame(maxWidth: 150, maxHeight: 12)
     }
 
     private var indentUsing: some View {
         Picker("", selection: $inspectorModel.indentUsingSelection) {
             ForEach(inspectorModel.indentUsingList) {
                 Text($0.name)
+                    .font(.system(size: 11))
             }
         }
         .labelsHidden()
-        .modifier(CustomPickerView())
+        .frame(maxWidth: 150, maxHeight: 12)
+        .menuStyle(RedBorderMenuStyle())
     }
 
     private func changeFileName(newFileName: String) {
@@ -348,20 +367,10 @@ struct FileInspectorView: View {
     }
 }
 
-/// Custom picker
-struct CustomPickerView: ViewModifier {
-    func body(content: Content) -> some View {
-        content
-            .frame(maxWidth: 150, maxHeight: 11)
-            // TODO: Update max height on a better way
-            .clipped()
-            // Mask our ".clipped()" a bit
-            .mask(
-                RoundedRectangle(cornerRadius: 25, style: .continuous)
-            )
-            .overlay(
-                Capsule(style: .continuous)
-                    .stroke(.separator, style: StrokeStyle(lineWidth: 1))
-            )
+struct RedBorderMenuStyle: MenuStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Menu(configuration)
+            .font(.system(size: 11))
+            .border(Color.red)
     }
 }

--- a/AuroraEditor/Base/InspectorSidebar/UI/FileInspector/FileInspectorView.swift
+++ b/AuroraEditor/Base/InspectorSidebar/UI/FileInspector/FileInspectorView.swift
@@ -242,7 +242,7 @@ struct FileInspectorView: View {
                 }
             }
             Group {
-                Section(header: Text("Sourcecode Objective-C")) {
+                Section(header: Text("Sourcecode Script")) {
                     ForEach(inspectorModel.sourcecodeScriptList) {
                         Text($0.name)
                             .font(.system(size: 11))
@@ -352,7 +352,6 @@ struct FileInspectorView: View {
         }
         .labelsHidden()
         .frame(maxWidth: 150, maxHeight: 12)
-        .menuStyle(RedBorderMenuStyle())
     }
 
     private func changeFileName(newFileName: String) {
@@ -364,13 +363,5 @@ struct FileInspectorView: View {
             Log.error("Ooops! Something went wrong: \(error)")
             Log.info(fileName)
         }
-    }
-}
-
-struct RedBorderMenuStyle: MenuStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        Menu(configuration)
-            .font(.system(size: 11))
-            .border(Color.red)
     }
 }

--- a/AuroraEditor/DefaultThemes/auroraeditor-xcode-dark.json
+++ b/AuroraEditor/DefaultThemes/auroraeditor-xcode-dark.json
@@ -21,13 +21,13 @@
             "color" : "#67B7A4"
         },
         "lineHighlight" : {
-            "color" : "#23252B"
+            "color" : "#2f3239"
         },
         "values" : {
             "color" : "#A167E6"
         },
         "background" : {
-            "color" : "#1F1F24"
+            "color" : "#292a30"
         },
         "keywords" : {
             "color" : "#FF7AB3"
@@ -39,7 +39,7 @@
             "color" : "#D9D9D9"
         },
         "selection" : {
-            "color" : "#515B70"
+            "color" : "#636f83"
         },
         "types" : {
             "color" : "#5DD8FF"
@@ -54,7 +54,7 @@
             "color" : "#D0BF69"
         },
         "invisibles" : {
-            "color" : "#424D5B"
+            "color" : "#53606e"
         }
     },
     "terminal" : {

--- a/AuroraEditor/DefaultThemes/auroraeditor-xcode-light.json
+++ b/AuroraEditor/DefaultThemes/auroraeditor-xcode-light.json
@@ -21,7 +21,7 @@
             "color" : "#326D74"
         },
         "lineHighlight" : {
-            "color" : "#E8F2FF"
+            "color" : "#ecf5ff"
         },
         "values" : {
             "color" : "#6C36A9"
@@ -39,7 +39,7 @@
             "color" : "#262626"
         },
         "selection" : {
-            "color" : "#A4CDFF"
+            "color" : "#b2d7ff"
         },
         "types" : {
             "color" : "#0B4F79"
@@ -54,7 +54,7 @@
             "color" : "#1C00CF"
         },
         "invisibles" : {
-            "color" : "#CCCCCC"
+            "color" : "#d6d6d6"
         }
     },
     "terminal" : {


### PR DESCRIPTION
# Description
Fixed the theming color of the Xcode themes, and also allowed the text editor to display them.

Fixed Inspetor text sizes also...
<!--- REQUIRED: Describe what changed in detail -->

# Related Issue
<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* NONE

# Checklist

<!--- Add things that are not yet implemented above -->
- [X] I read and understood the [contributing guide](https://github.com/AuroraEditor/AuroraEditor/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/AuroraEditor/AuroraEditor/blob/main/CODE_OF_CONDUCT.md)
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] I documented my code
- [X] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
