### PR TITLE
Fix color issues with editor being lighter than that of Xcode

### DIFF
--- a/AuroraEditor/Assets.xcassets/Custom Colors/EditorBackground.colorset/Contents.json
+++ b/AuroraEditor/Assets.xcassets/Custom Colors/EditorBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2D",
+          "green" : "0x28",
+          "red" : "0x27"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AuroraEditor/Base/Breadcrumbs/UI/BreadcrumbsView.swift
+++ b/AuroraEditor/Base/Breadcrumbs/UI/BreadcrumbsView.swift
@@ -44,9 +44,7 @@ public struct BreadcrumbsView: View {
         .frame(height: 28, alignment: .center)
         .background {
             EffectView(
-                colorScheme == .dark
-                ? NSVisualEffectView.Material.windowBackground
-                : NSVisualEffectView.Material.contentBackground,
+                NSVisualEffectView.Material.contentBackground,
                 blendingMode: NSVisualEffectView.BlendingMode.withinWindow
             )
         }

--- a/AuroraEditor/Base/Documents/UI/WorkspaceView.swift
+++ b/AuroraEditor/Base/Documents/UI/WorkspaceView.swift
@@ -49,6 +49,7 @@ struct WorkspaceView: View {
 
     var noEditor: some View {
         ZStack {
+            Color("EditorBackground")
             Text("No Editor")
                 .font(.system(size: 17))
                 .foregroundColor(.secondary)

--- a/AuroraEditor/Base/TabBar/UI/TabBarXcode.swift
+++ b/AuroraEditor/Base/TabBar/UI/TabBarXcode.swift
@@ -14,9 +14,7 @@ struct TabBarXcodeBackground: View {
 
     var body: some View {
         EffectView(
-            colorScheme == .dark
-            ? NSVisualEffectView.Material.windowBackground
-            : NSVisualEffectView.Material.contentBackground,
+            NSVisualEffectView.Material.contentBackground,
             blendingMode: NSVisualEffectView.BlendingMode.withinWindow
         )
     }


### PR DESCRIPTION
# Description
The colour of the tab bar, editor, and breadcrumbs were lighter than that of Xcode, this PR fixes that so that it matches Xcodes color scheme correctly.

# Related Issue
<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* NONE

# Checklist

<!--- Add things that are not yet implemented above -->
- [X] I read and understood the [contributing guide](https://github.com/AuroraEditor/AuroraEditor/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/AuroraEditor/AuroraEditor/blob/main/CODE_OF_CONDUCT.md)
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] I documented my code
- [X] Review requested

# Screenshots
![Screenshot 2022-08-30 at 12 39 59](https://user-images.githubusercontent.com/63672227/187416419-b9ff7597-fbf3-4ff9-89da-11749d3ac000.png)

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
