### PR TITLE
fixed typo (posibility --> possibility) in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Developers should be able to use an editor that feels snappy and fast.
 
 Most comparable editors are built on Electron, This is a huge disadvantage because it utilize a lot of unneccecary system resources. Electron requires a Chromium instance to run. This can mean massive performance losses and high RAM usage even for small apps built on it. Additionally, the overall code footprint is much larger and animations are slower. More frames are lost and things like window resizing feels laggy. Native apps are smooth as butter and utilize system resources much more efficiently for better performance and reliability.
 
-Xcode is a great native editor for developers on Mac, but unfortunately it doesn't support creating a multitude of projects in different programming languages, and this is where Aurora Editor comes in. Aurora Editor wants to give developers the posibility of creating their desired projects in their desired language on a editor that is native and gives a similar experience, performance and feel than that of Xcode on Mac.
+Xcode is a great native editor for developers on Mac, but unfortunately it doesn't support creating a multitude of projects in different programming languages, and this is where Aurora Editor comes in. Aurora Editor wants to give developers the possibility of creating their desired projects in their desired language on a editor that is native and gives a similar experience, performance and feel than that of Xcode on Mac.
 
 ## Motivation for divergence from CodeEdit
 


### PR DESCRIPTION
# Description

There was a typo in the README. I changed it from **posibility to possibility**. The typo occurred in line 55.

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/AuroraEditor/AuroraEditor/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/AuroraEditor/AuroraEditor/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] I documented my code
- [ ] Review requested
