### PR TITLE
Move `filter` from wsclient to wsdocument

### DIFF
--- a/AuroraEditor/Base/Documents/Model/WorkspaceDocument/WorkspaceDocument.swift
+++ b/AuroraEditor/Base/Documents/Model/WorkspaceDocument/WorkspaceDocument.swift
@@ -25,6 +25,9 @@ final class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
 
     @Published
     var fileItems: [WorkspaceClient.FileItem] = []
+    public var filter: String = "" {
+        didSet { workspaceClient?.onRefresh() }
+    }
 
     var statusBarModel: StatusBarModel?
     var searchState: SearchState?

--- a/AuroraEditor/Base/NavigatorSidebar/Model/ProjectNavigator/ProjectNavigatorViewController.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/Model/ProjectNavigator/ProjectNavigatorViewController.swift
@@ -139,8 +139,8 @@ final class ProjectNavigatorViewController: NSViewController {
     /// Perform functions related to reloading the Outline View
     func reloadData() {
         self.outlineView.reloadData()
-        guard let workspaceClient = self.workspace?.workspaceClient else { return }
-        if !workspaceClient.filter.isEmpty {
+        guard let workspace = self.workspace else { return }
+        if !workspace.filter.isEmpty {
             // expand everything
             outlineView.expandItem(outlineView.item(atRow: 0), expandChildren: true)
         } else {
@@ -150,9 +150,9 @@ final class ProjectNavigatorViewController: NSViewController {
 
     /// Save the expansion state of the items in the Project Navigator
     func saveExpansionState() {
-        guard let workspaceClient = self.workspace?.workspaceClient,
+        guard let workspace = self.workspace,
               let workspaceItem = outlineView.item(atRow: 0) as? Item,
-              workspaceClient.filter.isEmpty && !isExpandingThings else { return }
+              workspace.filter.isEmpty && !isExpandingThings else { return }
         saveExpansionState(of: workspaceItem)
     }
 
@@ -191,9 +191,9 @@ final class ProjectNavigatorViewController: NSViewController {
 
 extension ProjectNavigatorViewController: NSOutlineViewDataSource {
     func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
-        guard let workspaceClient = self.workspace?.workspaceClient else { return 0 }
+        guard let workspace = self.workspace else { return 0 }
         if let item = item as? Item {
-            return item.appearanceWithinChildrenOf(searchString: workspaceClient.filter,
+            return item.appearanceWithinChildrenOf(searchString: workspace.filter,
                                                    ignoreDots: true,
                                                    ignoreTilde: true)
         }
@@ -201,11 +201,11 @@ extension ProjectNavigatorViewController: NSOutlineViewDataSource {
     }
 
     func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
-        guard let workspaceClient = self.workspace?.workspaceClient,
+        guard let workspace = self.workspace,
               let item = item as? Item
         else { return content[index] }
 
-        return item.childrenSatisfying(searchString: workspaceClient.filter,
+        return item.childrenSatisfying(searchString: workspace.filter,
                                        ignoreDots: true,
                                        ignoreTilde: true)[index]
     }

--- a/AuroraEditor/Base/NavigatorSidebar/UI/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/UI/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
@@ -33,7 +33,7 @@ struct ProjectNavigatorToolbarBottom: View {
                 }
             }
             .onChange(of: filter, perform: {
-                workspace.workspaceClient?.filter = $0
+                workspace.filter = $0
             })
             .padding(.vertical, 3)
             .background(.ultraThinMaterial)

--- a/AuroraEditor/Base/WorkspaceClient/Model/WorkspaceClient/WorkspaceClient.swift
+++ b/AuroraEditor/Base/WorkspaceClient/Model/WorkspaceClient/WorkspaceClient.swift
@@ -16,9 +16,6 @@ public class WorkspaceClient {
     /// callback function that is run when a change is detected in the file system.
     /// This usually contains a `reloadData` function.
     public var onRefresh: () -> Void = {}
-    public var filter: String = "" {
-        didSet { onRefresh() }
-    }
 
     // Variables for the outside to interface with
     public var getFiles: AnyPublisher<[FileItem], Never> =


### PR DESCRIPTION
# Description

Moved the `filter` property from workspace client to workspace document. The filter is used for project navigator filtering, which is less related to the file system and more to the document itself. 

# Related Issue

#40 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/AuroraEditor/AuroraEditor/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/AuroraEditor/AuroraEditor/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
