### PR TITLE
Remove dock progress if git clone was cancelled

### DIFF
--- a/AuroraEditor/Base/Git/UI/Clone/GitCloneView+Helpers.swift
+++ b/AuroraEditor/Base/Git/UI/Clone/GitCloneView+Helpers.swift
@@ -69,6 +69,7 @@ extension GitCloneView {
     func cancelClone(deleteRemains: Bool = false) {
         isPresented = false
         cloneCancellable?.cancel()
+        NSApplication.shared.removeDockProgress()
 
         guard deleteRemains && FileManager.default.fileExists(atPath: repoPathStr) else { return }
         do {


### PR DESCRIPTION
# Description

Removes dock progress indicator if git clone was cancelled

# Related Issue

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/AuroraEditor/AuroraEditor/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/AuroraEditor/AuroraEditor/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
