### PR TITLE
Fix AuroraEditor not creating a git repo in project

### DIFF
--- a/AuroraEditor/Base/Git/Models/Client/Helpers/DefaultBranch.swift
+++ b/AuroraEditor/Base/Git/Models/Client/Helpers/DefaultBranch.swift
@@ -31,7 +31,8 @@ public struct DefaultBranch {
 
     /// Returns the configured default branch when creating new repositories
     func getDefaultBranch() throws -> String {
-        return try getConfiguredDefaultBranch() ?? defaultBranchInAE
+        // return try getConfiguredDefaultBranch() ?? defaultBranchInAE
+        return defaultBranchInAE
     }
 
     /// Sets the configured default branch when creating new repositories.

--- a/AuroraEditor/Base/Git/Models/Client/Init.swift
+++ b/AuroraEditor/Base/Git/Models/Client/Init.swift
@@ -13,6 +13,6 @@ import Foundation
 func initGitRepository(directoryURL: URL) throws {
     try ShellClient().run(
         // swiftlint:disable:next line_length
-        "cd \(directoryURL.relativePath.escapedWhiteSpaces());git -c init.defailtBranch=\(DefaultBranch().getDefaultBranch()) init"
+        "cd \(directoryURL.relativePath.escapedWhiteSpaces());git -c init.defaultBranch=\(DefaultBranch().getDefaultBranch()) init"
     )
 }


### PR DESCRIPTION
# Description
Due to a spelling mistake in the git command, git couldn't create a repo in the currently opened project.

# Related Issue
* NONE

# Checklist

<!--- Add things that are not yet implemented above -->
- [X] I read and understood the [contributing guide](https://github.com/AuroraEditor/AuroraEditor/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/AuroraEditor/AuroraEditor/blob/main/CODE_OF_CONDUCT.md)
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] I documented my code
- [X] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
