### PR TITLE
Fix issue with crash on close

### DIFF
--- a/AuroraEditor/Utils/Log/Log.swift
+++ b/AuroraEditor/Utils/Log/Log.swift
@@ -172,10 +172,12 @@ public class Log {
             message.append("\r\n")
         }
 
-        auroraMessageBox(
-            type: .critical,
-            message: message
-        )
+        DispatchQueue.main.async {
+            auroraMessageBox(
+                type: .critical,
+                message: message
+            )
+        }
 
         log(.error, items, separator, terminator, file, line, column, function)
     }

--- a/AuroraEditor/Utils/WorkspaceExtension.swift
+++ b/AuroraEditor/Utils/WorkspaceExtension.swift
@@ -11,14 +11,9 @@ import Foundation
 extension WorkspaceDocument {
 
     func workspaceURL() -> URL {
-        do {
-            guard let workspaceFolder = self.fileSystemClient?.folderURL else {
-                throw URLError(.fileDoesNotExist)
-            }
-            return workspaceFolder
-        } catch {
-            Log.error("Unable to get workspace url")
+        guard let workspaceFolder = self.fileSystemClient?.folderURL else {
+            fatalError("Unconstructable URL")
         }
-        return URL(string: "")!
+        return workspaceFolder
     }
 }


### PR DESCRIPTION
# Description
The cause of the issue was due to the `auroraErrorDialog` not running on the main thread. But it pops up a new error now.

Somewhere in the [SoucreControlModel.swift](https://github.com/AuroraEditor/AuroraEditor/blob/main/AuroraEditor/Base/NavigatorSidebar/Model/SourceControlNavigator/Changes/SourceControlModel.swift) it's running a function after the the application terminates and that function requires the projects URL.... I'm assuming it's the following line of code causing the issue [Line 85 till Line 108](https://github.com/AuroraEditor/AuroraEditor/blob/25f96cce8c93f5254a12a67a05489d87bfde32f0/AuroraEditor/Base/NavigatorSidebar/Model/SourceControlNavigator/Changes/SourceControlModel.swift#L85)

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* Fixes #245 

# Checklist

<!--- Add things that are not yet implemented above -->
- [X] I read and understood the [contributing guide](https://github.com/AuroraEditor/AuroraEditor/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/AuroraEditor/AuroraEditor/blob/main/CODE_OF_CONDUCT.md)
- [X] My changes generate no new warnings
- [X] My code builds and runs on my machine
- [X] I documented my code
- [X] Review requested

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
