### PR TITLE
Fix Line Issues (properly this time)

### DIFF
--- a/AuroraEditor/Base/Editor/CodeEditorView/UI/CodeView.swift
+++ b/AuroraEditor/Base/Editor/CodeEditorView/UI/CodeView.swift
@@ -230,10 +230,10 @@ class CodeView: NSTextView { // swiftlint:disable:this type_body_length
         // NB: We retain the last line and not the character index as the
         // latter may be inaccurate due to editing that let
         // to the selected range change.
-        if lineOfInsertionPoint != oldLastLineOfInsertionPoint {
+        if lineOfInsertionPoint != oldLastLineOfInsertionPoint, let codeStorage = optCodeStorage {
 
             if let oldLine = oldLastLineOfInsertionPoint,
-               let oldLineRange = optLineMap?.lookup(line: oldLine)?.range {
+               let oldLineRange = codeStorage.getLineRange(oldLine) {
 
                 // We need to invalidate the whole background (incl message views); hence, we need to employ
                 // `lineBackgroundRect(_:)`, which is why `NSLayoutManager.invalidateDisplay(forCharacterRange:)` is not
@@ -242,11 +242,9 @@ class CodeView: NSTextView { // swiftlint:disable:this type_body_length
 
                     self.setNeedsDisplay(self.lineBackgroundRect(fragmentRect))
                 }
-                minimapGutterView?.optLayoutManager?.invalidateDisplay(forCharacterRange: oldLineRange)
-
             }
             if let newLine = lineOfInsertionPoint,
-               let newLineRange = optLineMap?.lookup(line: newLine)?.range {
+               let newLineRange = codeStorage.getLineRange(newLine) {
 
                 // We need to invalidate the whole background (incl message views); hence, we need to employ
                 // `lineBackgroundRect(_:)`, which is why `NSLayoutManager.invalidateDisplay(forCharacterRange:)` is not
@@ -255,8 +253,6 @@ class CodeView: NSTextView { // swiftlint:disable:this type_body_length
 
                     self.setNeedsDisplay(self.lineBackgroundRect(fragmentRect))
                 }
-                minimapGutterView?.optLayoutManager?.invalidateDisplay(forCharacterRange: newLineRange)
-
             }
         }
         oldLastLineOfInsertionPoint = lineOfInsertionPoint
@@ -271,8 +267,8 @@ class CodeView: NSTextView { // swiftlint:disable:this type_body_length
             // a lack of invalidation of the line on which the insertion point is located.
             self.gutterView?.invalidateGutter(forCharRange: combinedRanges(ranges: oldSelectedRanges))
             self.gutterView?.invalidateGutter(forCharRange: combinedRanges(ranges: ranges))
-            self.minimapGutterView?.invalidateGutter(forCharRange: combinedRanges(ranges: oldSelectedRanges))
-            self.minimapGutterView?.invalidateGutter(forCharRange: combinedRanges(ranges: ranges))
+//            self.minimapGutterView?.invalidateGutter(forCharRange: combinedRanges(ranges: oldSelectedRanges))
+//            self.minimapGutterView?.invalidateGutter(forCharRange: combinedRanges(ranges: ranges))
         }
 
         collapseMessageViews()

--- a/AuroraEditor/Base/Editor/CodeEditorView/UI/EditorAccessories/Gutter/GutterSharedCode.swift
+++ b/AuroraEditor/Base/Editor/CodeEditorView/UI/EditorAccessories/Gutter/GutterSharedCode.swift
@@ -36,8 +36,10 @@ extension GutterView {
 
         let textRect: CGRect
 
-        if charRange.location == string.length {   // special case: insertion point on trailing empty line
-            textRect = layoutManager.extraLineFragmentRect
+        if charRange.location >= string.length {    // special case: insertion point on trailing empty line
+                                                    // or beyond the end of the string (just deleted last trailing line)
+            let fragRect = layoutManager.extraLineFragmentRect
+            textRect = CGRect(x: fragRect.minX, y: fragRect.minY, width: fragRect.width, height: fragRect.height*2)
         } else {
             // We call `paragraphRange(for:_)` safely by boxing `charRange` to the allowed range.
             let extendedCharRange = string.paragraphRange(


### PR DESCRIPTION
# Description

This PR does three things.
1. Adds a bit of access safety to the theme applier, to avoid applying themes to ranges outside of the AttributedString.
2. Changes up the function that tells the gutter view to reload, so that it now reloads properly instead of creating a bunch of "ghost" lines.
3. Changes up the function that determines the line range to update so that it doesn't cause an out of bounds error

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* Retry of #307 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] I read and understood the [contributing guide](https://github.com/AuroraEditor/AuroraEditor/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/AuroraEditor/AuroraEditor/blob/main/CODE_OF_CONDUCT.md)
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [x] Review requested

# Screenshots


https://user-images.githubusercontent.com/88234730/198631190-f1b1007d-5a23-4dd1-8017-a993682e88d6.mov


