### PR TITLE
Update automatic update screen (make it more clear)

### DIFF
--- a/AuroraEditor/Base/AppPreferences/UI/UpdatesPreferences/UpdatePreferencesView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/UpdatesPreferences/UpdatePreferencesView.swift
@@ -101,8 +101,6 @@ struct UpdatePreferencesView: View {
             }
         }
         .onAppear {
-            // We disable checking for updates in debug builds as to not
-            // annoy our fellow contributers
             updateModel.checkForUpdates()
         }
     }

--- a/AuroraEditor/Base/AppPreferences/UI/UpdatesPreferences/UpdatePreferencesView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/UpdatesPreferences/UpdatePreferencesView.swift
@@ -27,6 +27,14 @@ struct UpdatePreferencesView: View {
         Bundle.commitHash ?? "No Hash"
     }
 
+    private var isUpdateButtonDisabled: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+
     private var shortCommitHash: String {
         if commitHash.count > 7 {
             return String(commitHash[...commitHash.index(commitHash.startIndex, offsetBy: 7)])
@@ -66,7 +74,7 @@ struct UpdatePreferencesView: View {
                         Link("Learn more...",
                              destination: URL(string: "https://auroraeditor.com")!)
                         .font(.system(size: 11))
-                        .foregroundColor(.blue)
+                        .foregroundColor(.accentColor)
                     }
                     .padding(5)
                 }
@@ -95,9 +103,7 @@ struct UpdatePreferencesView: View {
         .onAppear {
             // We disable checking for updates in debug builds as to not
             // annoy our fellow contributers
-            #if !DEBUG
             updateModel.checkForUpdates()
-            #endif
         }
     }
 
@@ -166,6 +172,7 @@ struct UpdatePreferencesView: View {
                     HStack {
                         Text("Update Available")
                             .font(.system(size: 12, weight: .medium))
+
                         Spacer()
                         Button {
 
@@ -175,7 +182,7 @@ struct UpdatePreferencesView: View {
                     }
 
                     HStack {
-                        Text("* Aurora Editor Nightly Build")
+                        Text("\u{00B7} Aurora Editor Nightly Build")
                             .foregroundColor(.secondary)
 
                         Spacer()
@@ -184,17 +191,22 @@ struct UpdatePreferencesView: View {
                             .foregroundColor(.secondary)
                     }
 
-                    Divider()
+                    if isUpdateButtonDisabled {
+                        Text("\u{26A0} You are using a debug build, therefore updating is disabled.")
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                            .padding(5)
+                    }
 
-                    Text("More Info...")
-                        .font(.system(size: 11))
-                        .foregroundColor(.blue)
-                        .padding(.vertical, 5)
-
+                    Link("Learn more...",
+                         destination: URL(string: "https://auroraeditor.com")!)
+                    .font(.system(size: 11))
+                    .foregroundColor(.accentColor)
                 }
                 .padding(5)
             }
             .padding(5)
+            .disabled(isUpdateButtonDisabled)
         }
     }
 


### PR DESCRIPTION
# Description

make it more clear that a debug build is running and therefore automatic updating is disabled.
changed `.foregroundColor(.blue)` to `.foregroundColor(.accentColor)`

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
N/A

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<img width="872" alt="image" src="https://user-images.githubusercontent.com/1290461/210426229-d7b83504-b611-42d6-b9bc-5822b5afe868.png">

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->