### PR TITLE
Allow customisation for banned file prefixes

### DIFF
--- a/AuroraEditor/Base/FileSystemClient/Model/FileItem/FileItem.swift
+++ b/AuroraEditor/Base/FileSystemClient/Model/FileItem/FileItem.swift
@@ -241,6 +241,7 @@ public extension FileSystemClient {
         /// that contain the `searchString` in their path or their subitems' paths.
         /// Returns `0` if the item is not a folder.
         /// - Parameter searchString: The string
+        /// - Parameter ignoredStrings: The prefixes to ignore if they prefix file names
         /// - Returns: The number of children that match the conditiions
         public func appearanceWithinChildrenOf(searchString: String,
                                                ignoredStrings: [String] = [".", "~"]) -> Int {
@@ -271,6 +272,7 @@ public extension FileSystemClient {
         /// Similar to `appearanceWithinChildrenOf(searchString: String)`
         /// Returns `[]` if the item is not a folder.
         /// - Parameter searchString: The string
+        /// - Parameter ignoredStrings: The prefixes to ignore if they prefix file names
         /// - Returns: The children that match the conditiions
         public func childrenSatisfying(searchString: String,
                                        ignoredStrings: [String] = [".", "~"]) -> [FileItem] {

--- a/AuroraEditor/Base/FileSystemClient/Model/FileItem/FileItem.swift
+++ b/AuroraEditor/Base/FileSystemClient/Model/FileItem/FileItem.swift
@@ -243,13 +243,19 @@ public extension FileSystemClient {
         /// - Parameter searchString: The string
         /// - Returns: The number of children that match the conditiions
         public func appearanceWithinChildrenOf(searchString: String,
-                                               ignoreDots: Bool = true,
-                                               ignoreTilde: Bool = true) -> Int {
+                                               ignoredStrings: [String] = [".", "~"]) -> Int {
             var count = 0
             guard self.isFolder else { return 0 }
             for child in self.children ?? [] {
-                if ignoreDots && child.fileName.starts(with: ".") { continue }
-                if ignoreTilde && child.fileName.starts(with: "~") { continue }
+                var isIgnored: Bool = false
+                for ignoredString in ignoredStrings where child.fileName.hasPrefix(ignoredString) {
+                    isIgnored = true // can use regex later
+                }
+
+                if isIgnored {
+                    continue
+                }
+
                 guard !searchString.isEmpty else { count += 1; continue }
                 if child.isFolder {
                     count += child.appearanceWithinChildrenOf(searchString: searchString) > 0 ? 1 : 0
@@ -267,13 +273,19 @@ public extension FileSystemClient {
         /// - Parameter searchString: The string
         /// - Returns: The children that match the conditiions
         public func childrenSatisfying(searchString: String,
-                                       ignoreDots: Bool = true,
-                                       ignoreTilde: Bool = true) -> [FileItem] {
+                                       ignoredStrings: [String] = [".", "~"]) -> [FileItem] {
             var satisfyingChildren: [FileItem] = []
             guard self.isFolder else { return [] }
             for child in self.children ?? [] {
-                if ignoreDots && child.fileName.starts(with: ".") { continue }
-                if ignoreTilde && child.fileName.starts(with: "~") { continue }
+                var isIgnored: Bool = false
+                for ignoredString in ignoredStrings where child.fileName.hasPrefix(ignoredString) {
+                    isIgnored = true // can use regex later
+                }
+
+                if isIgnored {
+                    continue
+                }
+
                 guard !searchString.isEmpty else { satisfyingChildren.append(child); continue }
                 if child.isFolder {
                     if child.appearanceWithinChildrenOf(searchString: searchString) > 0 {

--- a/AuroraEditor/Base/NavigatorSidebar/Model/ProjectNavigator/ProjectNavigatorOutlineDataSource.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/Model/ProjectNavigator/ProjectNavigatorOutlineDataSource.swift
@@ -12,9 +12,7 @@ extension ProjectNavigatorViewController: NSOutlineViewDataSource {
     func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
         guard let workspace = self.workspace else { return 0 }
         if let item = item as? Item {
-            return item.appearanceWithinChildrenOf(searchString: workspace.filter,
-                                                   ignoreDots: true,
-                                                   ignoreTilde: true)
+            return item.appearanceWithinChildrenOf(searchString: workspace.filter)
         }
         return content.count
     }
@@ -24,9 +22,7 @@ extension ProjectNavigatorViewController: NSOutlineViewDataSource {
               let item = item as? Item
         else { return content[index] }
 
-        return item.childrenSatisfying(searchString: workspace.filter,
-                                       ignoreDots: true,
-                                       ignoreTilde: true)[index]
+        return item.childrenSatisfying(searchString: workspace.filter)[index]
     }
 
     func outlineView(_ outlineView: NSOutlineView, isItemExpandable item: Any) -> Bool {


### PR DESCRIPTION
# Description

Instead of hard coding banned file prefixes to only `.` and `~`, this PR allows custom banned prefixes

This PR does not include UI, but it would likely go into the Settings or Project Settings window.

In the future, the prefix system would be replaced by a regex system for more possibilities in preventing certain files from showing up.

# Related Issue

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code

# Screenshots

no visual distinction