### PR TITLE
Make Preferences window resizable so that user can see all of contents.

### DIFF
--- a/AuroraEditor/Base/AppPreferences/Controller/PreferencesWindowController.swift
+++ b/AuroraEditor/Base/AppPreferences/Controller/PreferencesWindowController.swift
@@ -16,7 +16,6 @@ final class PreferencesWindowController: NSWindowController, NSToolbarDelegate {
         self.init(window: window)
         window.title = "Preferences"
         window.styleMask.insert(.fullSizeContentView)
-        window.styleMask.remove(.resizable)
         window.titlebarSeparatorStyle = .none
     }
 

--- a/AuroraEditor/Base/AppPreferences/UI/PreferencesView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/PreferencesView.swift
@@ -51,7 +51,12 @@ struct PreferencesView: View {
 
                 Text("No selection")
             }
-            .frame(width: 760, height: 500)
+            .frame(
+                minWidth: 760,
+                maxWidth: .infinity,
+                minHeight: 500,
+                maxHeight: .infinity
+            )
         }
     }
 


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->

We need more preference window size to solve this problem https://github.com/AuroraEditor/AuroraEditor/issues/350

# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #350 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [ ] I documented my code
- [ ] I added localization
- [ ] I added tests (and they pass)

# Screenshots

<!--- REQUIRED: if issue is UI related -->

|Before (user can't see of all colors)|After (user can expand window size)|
|---|---|
|<img width="872" alt="Screenshot 2023-02-09 at 14 26 18" src="https://user-images.githubusercontent.com/44002126/217726793-f5479284-6fd2-4c7e-9a50-00ed623cec88.png">|<img width="1156" alt="Screenshot 2023-02-09 at 14 28 18" src="https://user-images.githubusercontent.com/44002126/217726812-82522374-261e-4c18-8cdc-705efe71d1d8.png">|


<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->
