### PR TITLE
Remember if InspectorSidebar is open or not.

### DIFF
--- a/AuroraEditor/Base/AppPreferences/Model/General/GeneralPreferences.swift
+++ b/AuroraEditor/Base/AppPreferences/Model/General/GeneralPreferences.swift
@@ -57,6 +57,7 @@ public extension AppPreferences {
         /// The reveal file in navigator when focus changes behavior of the app.
         public var revealFileOnFocusChange: Bool = false
 
+        /// The fag whether inspectors side-bar should open by default or not.
         public var keepInspectorSidebarOpen: Bool = true
 
         /// Default initializer

--- a/AuroraEditor/Base/Documents/Model/AuroraEditorWindow/AuroraEditorWindowController+NSToolbarDelegate.swift
+++ b/AuroraEditor/Base/Documents/Model/AuroraEditorWindow/AuroraEditorWindowController+NSToolbarDelegate.swift
@@ -177,6 +177,8 @@ extension AuroraEditorWindowController: NSToolbarDelegate {
         else { return }
 
         inspectorPane.animator().isCollapsed.toggle()
+        prefs.preferences.general.keepInspectorSidebarOpen = !inspectorPane.isCollapsed
+
         for (id, AEExt) in ExtensionsManager.shared.loadedExtensions {
             Log.info(id, "didToggleInspectorPane()")
             AEExt.respond(

--- a/AuroraEditor/Base/Documents/Model/AuroraEditorWindow/AuroraEditorWindowController.swift
+++ b/AuroraEditor/Base/Documents/Model/AuroraEditorWindow/AuroraEditorWindowController.swift
@@ -58,7 +58,7 @@ final class AuroraEditorWindowController: NSWindowController, ObservableObject {
         mainContent.titlebarSeparatorStyle = .line
         splitVC.addSplitViewItem(mainContent)
 
-        let inspectorView = InspectorSidebar().environmentObject(workspace)
+        let inspectorView = InspectorSidebar(prefs: prefs).environmentObject(workspace)
         let inspector = NSSplitViewItem(
             viewController: NSHostingController(rootView: inspectorView)
         )

--- a/AuroraEditor/Base/InspectorSidebar/UI/InspectorSidebar.swift
+++ b/AuroraEditor/Base/InspectorSidebar/UI/InspectorSidebar.swift
@@ -22,6 +22,8 @@ struct InspectorSidebar: View {
     @State
     private var selection: Int = 0
 
+    let prefs: AppPreferencesModel
+
     var body: some View {
         VStack {
             if let item = workspace.selectionState.openFileItems.first(where: { file in
@@ -52,6 +54,7 @@ struct InspectorSidebar: View {
             maxHeight: .infinity,
             alignment: .top
         )
+        .isHidden(!prefs.preferences.general.keepInspectorSidebarOpen)
         .safeAreaInset(edge: .top) {
             InspectorSidebarToolbarTop(selection: $selection)
                 .padding(.bottom, -8)


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->

In this PR, I implement the memorization that `InspectorSidebar` is previously opened or not.
But, to solve the blow issue completely, we also need to memorize each splitViewItem's size.
I will address it on #425 

<img width="640" src="https://user-images.githubusercontent.com/44002126/218377342-d60a38b1-c646-4f37-9ce7-4318cbe457cd.jpg">


# Related Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #236 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [ ] I added localization
- [ ] I added tests (and they pass)

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->


![Screen Recording 2023-02-12 at 13 51 19](https://user-images.githubusercontent.com/44002126/218293699-dd106ebb-61b5-48ae-b600-f68e506d9ac6.gif)
