### PR TITLE
Remember splitView width of AuroraEditorWindow

### DIFF
--- a/Aurora Editor.xcodeproj/project.pbxproj
+++ b/Aurora Editor.xcodeproj/project.pbxproj
@@ -520,6 +520,7 @@
 		B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3327DA9E1000EA4DBD /* Assets.xcassets */; };
 		B6EE989027E8879A00CDD8AB /* InspectorSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EE988F27E8879A00CDD8AB /* InspectorSidebar.swift */; };
 		B6EE989227E887C600CDD8AB /* InspectorSidebarToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EE989127E887C600CDD8AB /* InspectorSidebarToolbar.swift */; };
+		D3C2DA4A29990FB900FA9F4C /* AuroraSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C2DA4929990FB900FA9F4C /* AuroraSplitViewController.swift */; };
 		D7012EE827E757850001E1EF /* FindNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7012EE727E757850001E1EF /* FindNavigator.swift */; };
 		D7211D4327E066CE008F2ED7 /* Localized+Ex.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7211D4227E066CE008F2ED7 /* Localized+Ex.swift */; };
 		D7211D4727E06BFE008F2ED7 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D7211D4927E06BFE008F2ED7 /* Localizable.strings */; };
@@ -1141,6 +1142,7 @@
 		B658FB4727DA9E1000EA4DBD /* Aurora Editor (UITests).xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Aurora Editor (UITests).xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6EE988F27E8879A00CDD8AB /* InspectorSidebar.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = InspectorSidebar.swift; sourceTree = "<group>"; tabWidth = 4; };
 		B6EE989127E887C600CDD8AB /* InspectorSidebarToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorSidebarToolbar.swift; sourceTree = "<group>"; };
+		D3C2DA4929990FB900FA9F4C /* AuroraSplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuroraSplitViewController.swift; sourceTree = "<group>"; };
 		D7012EE727E757850001E1EF /* FindNavigator.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = FindNavigator.swift; sourceTree = "<group>"; tabWidth = 4; };
 		D7211D4227E066CE008F2ED7 /* Localized+Ex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Localized+Ex.swift"; sourceTree = "<group>"; };
 		D7211D4827E06BFE008F2ED7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1235,6 +1237,7 @@
 				206B128028DF7311002CDE51 /* EmptyEditorView.swift */,
 				0485EB1E27E7458B00138301 /* WorkspaceCodeFileView.swift */,
 				B658FB3127DA9E0F00EA4DBD /* WorkspaceView.swift */,
+				D3C2DA4929990FB900FA9F4C /* AuroraSplitViewController.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -3840,6 +3843,7 @@
 				93813D2428D749CC00A492D4 /* CodeViewDelegate.swift in Sources */,
 				2032B50E28A256130089EBB6 /* Collection.swift in Sources */,
 				2093CDDE289AA522003A88DD /* Color.swift in Sources */,
+				D3C2DA4A29990FB900FA9F4C /* AuroraSplitViewController.swift in Sources */,
 				2B04575528E6FFE300024F2D /* ColorThemeAttribute.swift in Sources */,
 				93EF416328C1D752004083AD /* Command.swift in Sources */,
 				93EF416128C1D38E004083AD /* CommandPaletteItem.swift in Sources */,

--- a/AuroraEditor/Base/AppPreferences/Model/General/GeneralPreferences.swift
+++ b/AuroraEditor/Base/AppPreferences/Model/General/GeneralPreferences.swift
@@ -60,6 +60,14 @@ public extension AppPreferences {
         /// The fag whether inspectors side-bar should open by default or not.
         public var keepInspectorSidebarOpen: Bool = true
 
+        public var workspaceSidebarWidth: Double = Self.defaultWorkspaceSidebarWidth
+        public var navigationSidebarWidth: Double = Self.defaultNavigationSidebarWidth
+        public var inspectorSidebarWidth: Double = Self.defaultInspectorSidebarWidth
+
+        private static let defaultInspectorSidebarWidth: Double = 260
+        private static let defaultNavigationSidebarWidth: Double = 260
+        private static let defaultWorkspaceSidebarWidth: Double = 260
+
         /// Default initializer
         public init() {}
 
@@ -130,6 +138,18 @@ public extension AppPreferences {
                 Bool.self,
                 forKey: .keepInspectorSidebarOpen
             ) ?? true
+            self.navigationSidebarWidth = try container.decodeIfPresent(
+                Double.self,
+                forKey: .navigationSidebarWidth
+            ) ?? Self.defaultNavigationSidebarWidth
+            self.workspaceSidebarWidth = try container.decodeIfPresent(
+                Double.self,
+                forKey: .workspaceSidebarWidth
+            ) ?? Self.defaultWorkspaceSidebarWidth
+            self.inspectorSidebarWidth = try container.decodeIfPresent(
+                Double.self,
+                forKey: .inspectorSidebarWidth
+            ) ?? Self.defaultInspectorSidebarWidth
         }
         // swiftlint:enable function_body_length
     }

--- a/AuroraEditor/Base/AppPreferences/Model/General/GeneralPreferences.swift
+++ b/AuroraEditor/Base/AppPreferences/Model/General/GeneralPreferences.swift
@@ -64,6 +64,10 @@ public extension AppPreferences {
         public var navigationSidebarWidth: Double = Self.defaultNavigationSidebarWidth
         public var inspectorSidebarWidth: Double = Self.defaultInspectorSidebarWidth
 
+        public var auroraEditorWindowWidth: Double {
+            navigationSidebarWidth + workspaceSidebarWidth + inspectorSidebarWidth
+        }
+
         private static let defaultInspectorSidebarWidth: Double = 260
         private static let defaultNavigationSidebarWidth: Double = 260
         private static let defaultWorkspaceSidebarWidth: Double = 260

--- a/AuroraEditor/Base/Documents/Model/AuroraEditorWindow/AuroraEditorWindowController.swift
+++ b/AuroraEditor/Base/Documents/Model/AuroraEditorWindow/AuroraEditorWindowController.swift
@@ -33,17 +33,7 @@ final class AuroraEditorWindowController: NSWindowController, ObservableObject {
         setupSplitView(with: self.workspace)
         setupToolbar()
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self else {
-                return
-            }
-            self.window?.setContentSize(
-                CGSize(
-                    width: self.prefs.preferences.general.auroraEditorWindowWidth,
-                    height: 600
-                )
-            )
-        }
+        updateLayoutOfWindowAndSplitView()
     }
 
     @available(*, unavailable)
@@ -87,19 +77,6 @@ final class AuroraEditorWindowController: NSWindowController, ObservableObject {
 
         workspace.broadcaster.broadcaster
             .sink(receiveValue: recieveCommand).store(in: &cancelables)
-
-        DispatchQueue.main.async { [weak prefs] in
-            guard let prefs else {
-                return
-            }
-            let navigationSidebarWidth = prefs.preferences.general.navigationSidebarWidth
-            let workspaceSidebarWidth = prefs.preferences.general.workspaceSidebarWidth
-            let firstDividerPos = navigationSidebarWidth
-            let secondDividerPos = navigationSidebarWidth + workspaceSidebarWidth
-            splitVC.splitView.setPosition(firstDividerPos, ofDividerAt: 0)
-            splitVC.splitView.setPosition(secondDividerPos, ofDividerAt: 1)
-            splitVC.splitView.layoutSubtreeIfNeeded()
-        }
     }
 
     override func close() {
@@ -109,6 +86,29 @@ final class AuroraEditorWindowController: NSWindowController, ObservableObject {
 
     override func windowDidLoad() {
         super.windowDidLoad()
+    }
+
+    @objc
+    private func updateLayoutOfWindowAndSplitView() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
+            }
+            let navigationSidebarWidth = self.prefs.preferences.general.navigationSidebarWidth
+            let workspaceSidebarWidth = self.prefs.preferences.general.workspaceSidebarWidth
+            let firstDividerPos = navigationSidebarWidth
+            let secondDividerPos = navigationSidebarWidth + workspaceSidebarWidth
+
+            self.window?.setContentSize(
+                CGSize(
+                    width: self.prefs.preferences.general.auroraEditorWindowWidth,
+                    height: 600
+                )
+            )
+            self.splitViewController.splitView.setPosition(firstDividerPos, ofDividerAt: 0)
+            self.splitViewController.splitView.setPosition(secondDividerPos, ofDividerAt: 1)
+            self.splitViewController.splitView.layoutSubtreeIfNeeded()
+        }
     }
 
     private func getSelectedCodeFile() -> CodeFileDocument? {

--- a/AuroraEditor/Base/Documents/Model/WorkspaceDocument/WorkspaceDocument.swift
+++ b/AuroraEditor/Base/Documents/Model/WorkspaceDocument/WorkspaceDocument.swift
@@ -82,7 +82,6 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered, defer: false
         )
-        window.center()
         window.minSize = .init(width: 1000, height: 600)
         let windowController = AuroraEditorWindowController(
             window: window,
@@ -90,6 +89,9 @@ class WorkspaceDocument: NSDocument, ObservableObject, NSToolbarDelegate {
         )
         self.addWindowController(windowController)
         self.windowController = windowController
+        DispatchQueue.main.async {
+            window.center()
+        }
     }
 
     // MARK: Set Up Workspace

--- a/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
+++ b/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
@@ -43,6 +43,7 @@ class AuroraSplitViewController: NSSplitViewController {
                 }
                 /// Note: in case, other stuff of ``AppPreferences/GeneralPreferences`` is updated,
                 /// we only update the properties which can be updated in ``AuroraSplitViewController``.
+                Log.info(general)
                 prefs.preferences.general.navigationSidebarWidth = general.navigationSidebarWidth
                 prefs.preferences.general.workspaceSidebarWidth = general.workspaceSidebarWidth
                 prefs.preferences.general.inspectorSidebarWidth = general.inspectorSidebarWidth
@@ -61,6 +62,13 @@ class AuroraSplitViewController: NSSplitViewController {
 
     override func splitViewDidResizeSubviews(_ notification: Notification) {
         if !calledViewDidAppear {
+            return
+        }
+        // Workaround
+        // this method `splitViewDidResizeSubviews` is also called when current window is about to be closed.
+        // then, somehow splitViewItem size is not correct (like set to zero).
+        // so I would like to skip the case some of the splitViewItems has zero size.
+        guard splitView.subviews.isEmpty == false, splitView.subviews.allSatisfy({ $0.frame.width != .zero }) else {
             return
         }
         var prefsKeyPath: [WritableKeyPath<AppPreferences.GeneralPreferences, Double>] = []

--- a/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
+++ b/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
@@ -71,19 +71,17 @@ class AuroraSplitViewController: NSSplitViewController {
         guard splitView.subviews.isEmpty == false, splitView.subviews.allSatisfy({ $0.frame.width != .zero }) else {
             return
         }
-        var prefsKeyPath: [WritableKeyPath<AppPreferences.GeneralPreferences, Double>] = []
-        var general = prefs.preferences.general
-        var subViews: [NSView] = []
-        prefsKeyPath = [
+        let prefsKeyPath: [WritableKeyPath<AppPreferences.GeneralPreferences, Double>] = [
             \.navigationSidebarWidth,
             \.workspaceSidebarWidth,
             \.inspectorSidebarWidth
         ]
-        subViews = [
+        let subViews = [
             splitView.subviews[0],
             splitView.subviews[1],
             splitView.subviews[2]
         ]
+        var general = prefs.preferences.general
         for (sidebar, keyPath) in zip(subViews, prefsKeyPath) {
             let width = sidebar.frame.size.width
             general[keyPath: keyPath] = width

--- a/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
+++ b/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
@@ -44,7 +44,6 @@ class AuroraSplitViewController: NSSplitViewController {
                 }
                 /// Note: in case, other stuff of ``AppPreferences/GeneralPreferences`` is updated,
                 /// we only update the properties which can be updated in ``AuroraSplitViewController``.
-                Log.info(general)
                 prefs.preferences.general.navigationSidebarWidth = general.navigationSidebarWidth
                 prefs.preferences.general.workspaceSidebarWidth = general.workspaceSidebarWidth
                 prefs.preferences.general.inspectorSidebarWidth = general.inspectorSidebarWidth

--- a/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
+++ b/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
@@ -12,7 +12,8 @@ import Combine
 /// AuroraSplitViewController
 ///
 /// `AuroraSplitViewController` is defined so that we observe resize event for SplitView subViews.
-/// By observing such a resize event, we can memorize latest size of ``NavigatorSidebar``/``WorkspaceView`` /``InspectorSidebar``
+/// By observing such a resize event, we can memorize latest size of
+/// ``NavigatorSidebar``/``WorkspaceView`` /``InspectorSidebar``
 /// whose sizes are stored inside ``AppPreferences/GeneralPreferences``.
 class AuroraSplitViewController: NSSplitViewController {
 

--- a/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
+++ b/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
@@ -11,9 +11,9 @@ import Combine
 
 /// AuroraSplitViewController
 ///
-/// `AuroraSplitViewController` is defined so that we observe resize event for SplitViewI subViews.
-/// By observing such a resize event, we can memorize latest size of ``InspectorSidebar`` .
-/// ``InspectorSidebar`` size is stored inside ``AppPreferences/GeneralPreferences/inspectorSidebarWidth``.
+/// `AuroraSplitViewController` is defined so that we observe resize event for SplitView subViews.
+/// By observing such a resize event, we can memorize latest size of ``NavigatorSidebar``/``WorkspaceView`` /``InspectorSidebar``
+/// whose sizes are stored inside ``AppPreferences/GeneralPreferences``.
 class AuroraSplitViewController: NSSplitViewController {
 
     let prefs: AppPreferencesModel

--- a/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
+++ b/AuroraEditor/Base/Documents/UI/AuroraSplitViewController.swift
@@ -1,0 +1,73 @@
+//
+//  AuroraSplitViewController.swift
+//  Aurora Editor
+//
+//  Created by Fumiya Tanaka on 2023/02/12.
+//  Copyright © 2023 Aurora Company. All rights reserved.
+//
+
+import Cocoa
+
+/// AuroraSplitViewController
+///
+/// `AuroraSplitViewController` is defined so that we observe resize event for SplitViewI subViews.
+/// By observing such a resize event, we can memorize latest size of ``InspectorSidebar`` .
+/// ``InspectorSidebar`` size is stored inside ``AppPreferences/GeneralPreferences/inspectorSidebarWidth``.
+class AuroraSplitViewController: NSSplitViewController {
+
+    let prefs: AppPreferencesModel
+
+    /// - Note: Before calling viewDidAppear, received size is kind of minimum size.
+    /// because it is not what user intends, we would like to skip such a default value to be persisted.
+    private var calledViewDidAppear: Bool = false
+
+    init(prefs: AppPreferencesModel) {
+        self.prefs = prefs
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        calledViewDidAppear = true
+    }
+
+    override func splitViewDidResizeSubviews(_ notification: Notification) {
+        guard let dividerIndex = notification.userInfo?["NSSplitViewDividerIndex"] as? Int else {
+            return
+        }
+        if !calledViewDidAppear {
+            return
+        }
+        var prefsKeyPath: [WritableKeyPath<AppPreferences, Double>] = []
+        var subViews: [NSView] = []
+        if dividerIndex == 0 {
+            prefsKeyPath = [
+                \AppPreferences.general.navigationSidebarWidth,
+                \AppPreferences.general.workspaceSidebarWidth
+            ]
+            subViews = [
+                splitView.subviews[0],
+                splitView.subviews[1]
+            ]
+        } else if dividerIndex == 1 {
+            prefsKeyPath = [
+                \AppPreferences.general.workspaceSidebarWidth,
+                \AppPreferences.general.inspectorSidebarWidth
+            ]
+            subViews = [
+                splitView.subviews[1],
+                splitView.subviews[2]
+            ]
+        } else {
+            return
+        }
+        for (sidebar, keyPath) in zip(subViews, prefsKeyPath) {
+            let width = sidebar.frame.size.width
+            prefs.preferences[keyPath: keyPath] = width
+        }
+    }
+}

--- a/AuroraEditor/Utils/Extensions/View.swift
+++ b/AuroraEditor/Utils/Extensions/View.swift
@@ -23,4 +23,34 @@ internal extension View {
             NSCursor.pop()
         }
     }
+
+    /// Change View according to `condition` parameter.
+    ///
+    /// We can use this like the below.
+    ///
+    ///     @State private var message = "Example"
+    ///     Text(message)
+    ///         .foregroundColor(Color.blue)
+    ///         .if(message.isEmpty) {
+    ///             $0.foregroundColor(Color.red)
+    ///         }
+    ///
+    /// - Parameters:
+    ///     - condition: the flag if we modify self with `whenTrue` closure.
+    ///     - whenTrue: return new View for `true` state.
+    ///     - whenFalse: return new View for `false`.
+    ///     This parameter is optional and default value is `nil`.
+    ///     If `whenFalse` is nil, just return `self` as a View for `false` state.
+    func `if`(
+        _ condition: @autoclosure () -> Bool,
+        whenTrue: (Self) -> any View,
+        whenFalse: ((Self) -> any View)? = nil
+    ) -> AnyView {
+        if condition() {
+            return AnyView(whenTrue(self))
+        } else if let whenFalse {
+            return AnyView(whenFalse(self))
+        }
+        return AnyView(self)
+    }
 }

--- a/AuroraEditor/Utils/Extensions/View.swift
+++ b/AuroraEditor/Utils/Extensions/View.swift
@@ -23,34 +23,4 @@ internal extension View {
             NSCursor.pop()
         }
     }
-
-    /// Change View according to `condition` parameter.
-    ///
-    /// We can use this like the below.
-    ///
-    ///     @State private var message = "Example"
-    ///     Text(message)
-    ///         .foregroundColor(Color.blue)
-    ///         .if(message.isEmpty) {
-    ///             $0.foregroundColor(Color.red)
-    ///         }
-    ///
-    /// - Parameters:
-    ///     - condition: the flag if we modify self with `whenTrue` closure.
-    ///     - whenTrue: return new View for `true` state.
-    ///     - whenFalse: return new View for `false`.
-    ///     This parameter is optional and default value is `nil`.
-    ///     If `whenFalse` is nil, just return `self` as a View for `false` state.
-    func `if`(
-        _ condition: @autoclosure () -> Bool,
-        whenTrue: (Self) -> any View,
-        whenFalse: ((Self) -> any View)? = nil
-    ) -> AnyView {
-        if condition() {
-            return AnyView(whenTrue(self))
-        } else if let whenFalse {
-            return AnyView(whenFalse(self))
-        }
-        return AnyView(self)
-    }
 }


### PR DESCRIPTION
# Description

<!--- REQUIRED: Describe what changed in detail -->

To fix the below issue, 
- we need to memorize what size each splitViewItem has.
- we need to restore the previous size (width) preference of each splitViewItem when user relaunch AuroraEditor.

### My question

- Should we manage splitView size preference based on project?
   - I mean every project might be difference size prefs. if so, we will need to do enormous changes.
   - Answered at https://discord.com/channels/997410333348077620/1009439782402805800/1074767039476006912

### Note

For now, I only implemented the memorization of width. height one could be implemented in further PR.

### Issue

<!--- REQUIRED: Tag all related issues (e.g. * #23) -->
* #236 

# Checklist

<!--- Add things that are not yet implemented above -->
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] I documented my code
- [ ] I added localization
- [ ] I added tests (and they pass)

# Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

![Screen Recording 2023-02-14 at 7 40 38](https://user-images.githubusercontent.com/44002126/218591405-5d420f2f-22f9-4dc7-8689-a45e0cb1e0af.gif)

