### PR TITLE
`Text` to `LocalizedStringKey`, fixes #473

### DIFF
--- a/AuroraEditor/Base/AppPreferences/HelperViews/PreferencesColorPicker.swift
+++ b/AuroraEditor/Base/AppPreferences/HelperViews/PreferencesColorPicker.swift
@@ -26,7 +26,7 @@ struct PreferencesColorPicker: View {
             ColorPicker(selection: $color, supportsOpacity: false) { }
                 .labelsHidden()
             if let label = label {
-                Text(label)
+                Text(.init(label))
             }
         }
     }


### PR DESCRIPTION
# Description

Changed text with `.init(text)` so SwiftUI handles it as a `LocalizedStringKey`

# Related Issue

* #473 

# Checklist

- [x] I added localization

# Screenshots

<img width="872" alt="image" src="https://github.com/AuroraEditor/AuroraEditor/assets/1290461/ac1fa613-2a1f-4aae-9577-8d8008d021f4">