### PR TITLE
Fix interpolated string for account, fixes #502

### DIFF
--- a/AuroraEditor/Localization/af.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/af.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/cs.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/cs.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/cy.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/cy.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/da.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/da.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/de.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/de.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/el.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/el.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/en-001.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/en-001.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/en.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/en.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/es.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/es.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/fi.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/fi.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/fil.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/fil.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/fr.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/fr.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/ga.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ga.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/hi.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/hi.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/hr.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/hr.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/it.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/it.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/ja.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ja.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/ms.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ms.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/mt.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/mt.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/nb.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/nb.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/ne.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ne.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/nl.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/nl.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/pl.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/pl.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/pt-PT.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/pt-PT.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/ro.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ro.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/ru.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ru.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/sv.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/sv.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/th-TH.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/th-TH.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/th.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/th.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/tn.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/tn.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/uk.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/uk.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/vi.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/vi.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/xh-ZA.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/xh-ZA.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/zh-HK.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zh-HK.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zh-Hans.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/zh-Hant.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zh-Hant.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";

--- a/AuroraEditor/Localization/zu-ZA.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zu-ZA.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 
 "settings.account.show.profile" = "Show Profile...";
 "settings.account.username" = "Username";
-"settings.account.username.description" = "Your username is public and will represent you in %@";
+"settings.account.username.description %@" = "Your username is public and will represent you in %@";
 
 "settings.account.bitbucket.cloud" = "Bitbucket Cloud";
 "settings.account.bitbucket.server" = "Bitbucket Server";


### PR DESCRIPTION
## Summary
Fix for localized text in the accounts menu.

## Changes Made
Renamed `settings.account.username.description` to `settings.account.username.description %@` across translations. 

## Screenshots/GIFs
<img width="575" alt="Screenshot 2023-09-21 at 1 43 58 PM" src="https://github.com/AuroraEditor/AuroraEditor/assets/43875940/be7ed59a-065c-4f38-9e69-4e6d80afd223">



## Checklist

Please ensure all of the following are completed before submitting the PR:

- [ ] Code has been tested and verified.
- [ ] Documentation has been updated to reflect the changes.
- [ ] All tests pass successfully.
- [ ] Code follows the project's coding guidelines and style.
- [ ] The branch is up-to-date with the latest changes from the main branch.
- [ ] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): #502 

## Additional Notes

<!--- REQUIRED: If you have any additional notes, considerations, or context to add regarding this PR, please do so here. -->
