### PR TITLE
Localize settings.account.github in AccountSelectionDialog. Closes #501

### DIFF
--- a/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/AccountSelectionDialog.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/AccountSelectionDialog.swift
@@ -21,7 +21,7 @@ struct AccountSelectionDialog: View {
         Providers(name: "settings.account.bitbucket.server".localize(),
                   icon: "bitbucket",
                   id: "bitbucketServer"),
-        Providers(name: "settings.account.github",
+        Providers(name: "settings.account.github".localize(),
                   icon: "github",
                   id: "github"),
         Providers(name: "settings.account.github.enterprise".localize(),


### PR DESCRIPTION
## Summary

This fixes the bug that the text 'settings.account.github' was not localized in AccountSelectionDialog.

## Changes Made

The text is now correctly localized

## TODO

None.

## Motivation

Fixes the localization bug, therefore closing issue #501

## Testing

Run the project.

## Screenshots/GIFs


## Checklist

Please ensure all of the following are completed before submitting the PR:

- [X ] Code has been tested and verified.
- [ ] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully.
- [X] Code follows the project's coding guidelines and style.
- [X] The branch is up-to-date with the latest changes from the main branch.
- [ ] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): #501 

## Additional Notes

None.
