### PR TITLE
Fix GitHub login texts, login view window closing, sc-account id generation

### DIFF
--- a/AuroraEditor/Base/AppPreferences/Model/Accounts/EditorAccountModel.swift
+++ b/AuroraEditor/Base/AppPreferences/Model/Accounts/EditorAccountModel.swift
@@ -9,6 +9,8 @@
 import Foundation
 
 class EditorAccountModel: ObservableObject {
+    
+    typealias LoginSuccessfulCallback = () -> Void
 
     private var prefs: AppPreferencesModel = .shared
 
@@ -22,7 +24,7 @@ class EditorAccountModel: ObservableObject {
     }
 
     func loginAuroraEditor(email: String,
-                           password: String) {
+                           password: String, successCallback: @escaping LoginSuccessfulCallback) {
 
         let parameters: [String: Any] = [
             "email": email,
@@ -43,7 +45,7 @@ class EditorAccountModel: ObservableObject {
 
                     DispatchQueue.main.async {
                         self.prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
-                            SourceControlAccounts(id: login.user.id,
+                            SourceControlAccounts(id: "aurora-" + login.user.id,
                                                   gitProvider: "Aurora Editor",
                                                   gitProviderLink: "https://auroraeditor.com",
                                                   gitProviderDescription: "Official Aurora Editor Account",
@@ -55,8 +57,8 @@ class EditorAccountModel: ObservableObject {
                                                   gitSSHKey: "",
                                                   isTokenValid: true)
                         )
-
-                        self.dismissDialog = false
+                        self.dismissDialog.toggle()
+                        successCallback()
                     }
                     self.keychain.set(login.accessToken, forKey: "auroraeditor_access_\(email)")
                     self.keychain.set(login.refreshToken, forKey: "auroraeditor_refresh_\(email)")
@@ -71,7 +73,7 @@ class EditorAccountModel: ObservableObject {
 
     func loginGitlab(gitAccountName: String,
                      accountToken: String,
-                     accountName: String) {
+                     accountName: String, successCallback: @escaping LoginSuccessfulCallback) {
         let gitAccounts = prefs.preferences.accounts.sourceControlAccounts.gitAccount
 
         let config = GitlabTokenConfiguration(accountToken)
@@ -83,7 +85,7 @@ class EditorAccountModel: ObservableObject {
                 } else {
                     Log.info(user)
                     self.prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
-                        SourceControlAccounts(id: gitAccountName.lowercased(),
+                        SourceControlAccounts(id: "gitlab-" + gitAccountName.lowercased(),
                                               gitProvider: "Gitlab",
                                               gitProviderLink: "https://gitlab.com",
                                               gitProviderDescription: "Gitlab",
@@ -95,7 +97,8 @@ class EditorAccountModel: ObservableObject {
                                               gitSSHKey: "",
                                               isTokenValid: true))
                     self.keychain.set(accountToken, forKey: "gitlab_\(accountName)")
-                    self.dismissDialog = false
+                    self.dismissDialog.toggle()
+                    successCallback()
                 }
             case .failure(let error):
                 Log.error(error)
@@ -105,7 +108,7 @@ class EditorAccountModel: ObservableObject {
 
     func loginGitlabSelfHosted(gitAccountName: String,
                                accountToken: String,
-                               enterpriseLink: String) {
+                               enterpriseLink: String, successCallback: @escaping LoginSuccessfulCallback) {
         let gitAccounts = prefs.preferences.accounts.sourceControlAccounts.gitAccount
 
         let config = GitlabTokenConfiguration(accountToken,
@@ -118,7 +121,7 @@ class EditorAccountModel: ObservableObject {
                 } else {
                     Log.info(user)
                     self.prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
-                        SourceControlAccounts(id: gitAccountName.lowercased(),
+                        SourceControlAccounts(id: "gitlab-sh-" + gitAccountName.lowercased(),
                                               gitProvider: "Gitlab",
                                               gitProviderLink: enterpriseLink,
                                               gitProviderDescription: "Gitlab",
@@ -130,7 +133,8 @@ class EditorAccountModel: ObservableObject {
                                               gitSSHKey: "",
                                               isTokenValid: true))
                     self.keychain.set(accountToken, forKey: "gitlab_\(gitAccountName)_hosted")
-                    self.dismissDialog = false
+                    self.dismissDialog.toggle()
+                    successCallback()
                 }
             case .failure(let error):
                 Log.error(error)
@@ -139,7 +143,7 @@ class EditorAccountModel: ObservableObject {
     }
 
     func loginGithub(gitAccountName: String,
-                     accountToken: String) {
+                     accountToken: String, successCallback: @escaping LoginSuccessfulCallback) {
         let gitAccounts = prefs.preferences.accounts.sourceControlAccounts.gitAccount
 
         let config = GithubTokenConfiguration(accountToken)
@@ -152,7 +156,7 @@ class EditorAccountModel: ObservableObject {
                     Log.info(user)
                     DispatchQueue.main.async {
                         self.prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
-                            SourceControlAccounts(id: gitAccountName.lowercased(),
+                            SourceControlAccounts(id: "github-" + gitAccountName.lowercased(),
                                                   gitProvider: "GitHub",
                                                   gitProviderLink: "https://github.com",
                                                   gitProviderDescription: "GitHub",
@@ -166,6 +170,7 @@ class EditorAccountModel: ObservableObject {
                         self.keychain.set(accountToken, forKey: "github_\(user.login!)")
                     }
                     self.dismissDialog.toggle()
+                    successCallback()
                 }
             case .failure(let error):
                 Log.error(error)
@@ -176,7 +181,7 @@ class EditorAccountModel: ObservableObject {
     func loginGithubEnterprise(gitAccountName: String,
                                accountToken: String,
                                accountName: String,
-                               enterpriseLink: String) {
+                               enterpriseLink: String, successCallback: @escaping LoginSuccessfulCallback) {
         let gitAccounts = prefs.preferences.accounts.sourceControlAccounts.gitAccount
 
         let config = GithubTokenConfiguration(accountToken,
@@ -189,7 +194,7 @@ class EditorAccountModel: ObservableObject {
                 } else {
                     Log.info(user)
                     self.prefs.preferences.accounts.sourceControlAccounts.gitAccount.append(
-                        SourceControlAccounts(id: gitAccountName.lowercased(),
+                        SourceControlAccounts(id: "github-ent-" + gitAccountName.lowercased(),
                                               gitProvider: "GitHub",
                                               gitProviderLink: enterpriseLink,
                                               gitProviderDescription: "GitHub",
@@ -201,7 +206,8 @@ class EditorAccountModel: ObservableObject {
                                               gitSSHKey: "",
                                               isTokenValid: true))
                     self.keychain.set(accountToken, forKey: "github_\(accountName)_enterprise")
-                    self.dismissDialog = false
+                    self.dismissDialog.toggle()
+                    successCallback()
                 }
             case .failure(let error):
                 Log.error(error)

--- a/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/AccountItemView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/AccountItemView.swift
@@ -15,6 +15,8 @@ struct AccountItemView: View {
 
     @Binding
     var account: SourceControlAccounts
+    
+    var onDeleteCallback: (String) -> Void
 
     var body: some View {
         GroupBox {
@@ -62,11 +64,17 @@ struct AccountItemView: View {
 
                 Divider()
 
-                Text("settings.account.username.description \(account.gitProvider)")
-                    .foregroundColor(.secondary)
-                    .font(.system(size: 11))
-                    .padding(6)
-                    .padding(.horizontal, 5)
+                HStack {
+                    Text("settings.account.username.description \(account.gitProvider)")
+                        .foregroundColor(.secondary)
+                        .font(.system(size: 11))
+                        .padding(6)
+                        .padding(.horizontal, 5)
+                    Spacer()
+                    Button("global.delete") {
+                        onDeleteCallback(account.id)
+                    }
+                }
             }
         }
     }

--- a/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/AccountSelectionDialog.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/AccountSelectionDialog.swift
@@ -83,22 +83,26 @@ struct AccountSelectionDialog: View {
     private var openAccountLoginDialog: some View {
         switch providerSelection {
         case "auroraEditor":
-            AuroraEditorLoginView(dismissDialog: $openGitLogin)
+            AuroraEditorLoginView(dismissDialog: $openGitLogin, loginSuccessfulCallback: dismissView)
         case "bitbucketCloud":
             implementationNeeded
         case "bitbucketServer":
             implementationNeeded
         case "github":
-            GithubLoginView(dismissDialog: $openGitLogin)
+            GithubLoginView(dismissDialog: $openGitLogin, loginSuccessfulCallback: dismissView)
         case "githubEnterprise":
-            GithubEnterpriseLoginView(dismissDialog: $openGitLogin)
+            GithubEnterpriseLoginView(dismissDialog: $openGitLogin, loginSuccessfulCallback: dismissView)
         case "gitlab":
-            GitlabLoginView(dismissDialog: $openGitLogin)
+            GitlabLoginView(dismissDialog: $openGitLogin, loginSuccessfulCallback: dismissView)
         case "gitlabSelfHosted":
-            GitlabHostedLoginView(dismissDialog: $openGitLogin)
+            GitlabHostedLoginView(dismissDialog: $openGitLogin, loginSuccessfulCallback: dismissView)
         default:
             implementationNeeded
         }
+    }
+    
+    private func dismissView() {
+        self.dismiss()
     }
 
     private var implementationNeeded: some View {

--- a/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/Login/AuroraEditor/AuroraEditorLoginView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/Login/AuroraEditor/AuroraEditorLoginView.swift
@@ -23,10 +23,13 @@ struct AuroraEditorLoginView: View {
 
     @ObservedObject
     var accountModel: EditorAccountModel
+    
+    var loginSuccessfulCallback: EditorAccountModel.LoginSuccessfulCallback
 
-    init(dismissDialog: Binding<Bool>) {
+    init(dismissDialog: Binding<Bool>, loginSuccessfulCallback: @escaping EditorAccountModel.LoginSuccessfulCallback) {
         self._dismissDialog = dismissDialog
         self.accountModel = .init(dismissDialog: dismissDialog.wrappedValue)
+        self.loginSuccessfulCallback = loginSuccessfulCallback
     }
 
     var body: some View {
@@ -71,7 +74,8 @@ struct AuroraEditorLoginView: View {
                     } else {
                         Button {
                             accountModel.loginAuroraEditor(email: email,
-                                                           password: password)
+                                                           password: password, successCallback: loginSuccessfulCallback)
+                            self.dismissDialog = accountModel.dismissDialog
                         } label: {
                             Text("settings.global.login")
                                 .foregroundColor(.white)

--- a/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/Login/Github/GithubEnterpriseLoginView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/Login/Github/GithubEnterpriseLoginView.swift
@@ -21,10 +21,12 @@ struct GithubEnterpriseLoginView: View {
 
     @ObservedObject
     var accountModel: EditorAccountModel
+    var loginSuccessfulCallback: EditorAccountModel.LoginSuccessfulCallback
 
-    init(dismissDialog: Binding<Bool>) {
+    init(dismissDialog: Binding<Bool>, loginSuccessfulCallback: @escaping EditorAccountModel.LoginSuccessfulCallback) {
         self._dismissDialog = dismissDialog
         self.accountModel = .init(dismissDialog: dismissDialog.wrappedValue)
+        self.loginSuccessfulCallback = loginSuccessfulCallback
     }
 
     var body: some View {
@@ -77,7 +79,8 @@ struct GithubEnterpriseLoginView: View {
                             accountModel.loginGithubEnterprise(gitAccountName: accountName,
                                                                accountToken: accountToken,
                                                                accountName: accountName,
-                                                               enterpriseLink: eneterpriseLink)
+                                                               enterpriseLink: eneterpriseLink, successCallback: loginSuccessfulCallback)
+                            self.dismissDialog = accountModel.dismissDialog
                         } label: {
                             Text("settings.global.login")
                                 .foregroundColor(.white)

--- a/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/Login/Github/GithubLoginView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/Login/Github/GithubLoginView.swift
@@ -20,10 +20,13 @@ struct GithubLoginView: View {
 
     @ObservedObject
     var accountModel: EditorAccountModel
+    
+    var loginSuccessfulCallback: EditorAccountModel.LoginSuccessfulCallback
 
-    init(dismissDialog: Binding<Bool>) {
+    init(dismissDialog: Binding<Bool>, loginSuccessfulCallback: @escaping EditorAccountModel.LoginSuccessfulCallback) {
         self._dismissDialog = dismissDialog
         self.accountModel = .init(dismissDialog: dismissDialog.wrappedValue)
+        self.loginSuccessfulCallback = loginSuccessfulCallback
     }
 
     var body: some View {
@@ -111,7 +114,8 @@ struct GithubLoginView: View {
                     } else {
                         Button {
                             accountModel.loginGithub(gitAccountName: accountName,
-                                                     accountToken: accountToken)
+                                                     accountToken: accountToken, successCallback: loginSuccessfulCallback)
+                            self.dismissDialog = accountModel.dismissDialog
                         } label: {
                             Text("settings.global.login")
                                 .foregroundColor(.white)

--- a/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/Login/Gitlab/GitlabHostedLoginView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/Login/Gitlab/GitlabHostedLoginView.swift
@@ -20,10 +20,12 @@ struct GitlabHostedLoginView: View {
 
     @ObservedObject
     var accountModel: EditorAccountModel
+    var loginSuccessfulCallback: EditorAccountModel.LoginSuccessfulCallback
 
-    init(dismissDialog: Binding<Bool>) {
+    init(dismissDialog: Binding<Bool>, loginSuccessfulCallback: @escaping EditorAccountModel.LoginSuccessfulCallback) {
         self._dismissDialog = dismissDialog
         self.accountModel = .init(dismissDialog: dismissDialog.wrappedValue)
+        self.loginSuccessfulCallback = loginSuccessfulCallback
     }
 
     var body: some View {
@@ -74,7 +76,8 @@ struct GitlabHostedLoginView: View {
                         Button {
                             accountModel.loginGitlabSelfHosted(gitAccountName: accountName,
                                                                accountToken: accountToken,
-                                                               enterpriseLink: eneterpriseLink)
+                                                               enterpriseLink: eneterpriseLink, successCallback: loginSuccessfulCallback)
+                            self.dismissDialog = accountModel.dismissDialog
                         } label: {
                             Text("settings.global.login")
                                 .foregroundColor(.white)

--- a/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/Login/Gitlab/GitlabLoginView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/Login/Gitlab/GitlabLoginView.swift
@@ -20,10 +20,12 @@ struct GitlabLoginView: View {
 
     @ObservedObject
     var accountModel: EditorAccountModel
+    var loginSuccessfulCallback: EditorAccountModel.LoginSuccessfulCallback
 
-    init(dismissDialog: Binding<Bool>) {
+    init(dismissDialog: Binding<Bool>, loginSuccessfulCallback: @escaping EditorAccountModel.LoginSuccessfulCallback) {
         self._dismissDialog = dismissDialog
         self.accountModel = .init(dismissDialog: dismissDialog.wrappedValue)
+        self.loginSuccessfulCallback = loginSuccessfulCallback
     }
 
     var body: some View {
@@ -68,7 +70,8 @@ struct GitlabLoginView: View {
                         Button {
                             accountModel.loginGitlab(gitAccountName: accountName,
                                                      accountToken: accountToken,
-                                                     accountName: accountName)
+                                                     accountName: accountName, successCallback: loginSuccessfulCallback)
+                            self.dismissDialog = accountModel.dismissDialog
                         } label: {
                             Text("settings.global.login")
                                 .foregroundColor(.white)

--- a/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/PreferenceAccountsView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/AccountsPreferences/PreferenceAccountsView.swift
@@ -28,7 +28,7 @@ public struct PreferenceAccountsView: View {
                     .foregroundColor(.secondary)
             } else {
                 List($prefs.preferences.accounts.sourceControlAccounts.gitAccount) { account in
-                    AccountItemView(account: account)
+                    AccountItemView(account: account, onDeleteCallback: removeSourceControlAccount)
                 }
                 .frame(minHeight: 435)
                 .padding(.horizontal, -10)
@@ -51,13 +51,15 @@ public struct PreferenceAccountsView: View {
         }
     }
 
-    private func removeSourceControlAccount(selectedAccountId: String) {
+    func removeSourceControlAccount(selectedAccountId: String) {
         var gitAccounts = prefs.preferences.accounts.sourceControlAccounts.gitAccount
 
         for account in gitAccounts where account.id == selectedAccountId {
             let index = gitAccounts.firstIndex(of: account)
             gitAccounts.remove(at: index ?? 0)
         }
+        
+        prefs.preferences.accounts.sourceControlAccounts.gitAccount = gitAccounts
     }
 }
 

--- a/AuroraEditor/Localization/af.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/af.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/cs.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/cs.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/cy.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/cy.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/da.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/da.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/de.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/de.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/el.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/el.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/en-001.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/en-001.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/en.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/en.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/es.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/es.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/fi.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/fi.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/fil.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/fil.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/fr.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/fr.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/ga.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ga.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/hi.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/hi.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/hr.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/hr.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/it.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/it.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/ja.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ja.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/ms.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ms.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/mt.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/mt.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/nb.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/nb.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/ne.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ne.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/nl.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/nl.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/pl.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/pl.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/pt-PT.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/pt-PT.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/ro.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ro.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/ru.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ru.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/sv.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/sv.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/th-TH.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/th-TH.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/th.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/th.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/tn.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/tn.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/uk.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/uk.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/vi.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/vi.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/xh-ZA.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/xh-ZA.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/zh-HK.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zh-HK.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zh-Hans.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/zh-Hant.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zh-Hant.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";

--- a/AuroraEditor/Localization/zu-ZA.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zu-ZA.lproj/Localizable.strings
@@ -41,11 +41,11 @@
 "settings.aurora.login.password" = "Enter your Password";
 "settings.aurora.login.create" = "Create a Aurora Editor account";
 
-"settings.github.enterprise.login.header" = "Sign in to your GitHub account";
+"settings.github.enterprise.login.header" = "Sign in to your GitHub Enterprise account";
 "settings.github.enterprise.login.enter.token" = "Enter your Personal Access Token";
 "settings.github.enterprise.login.create" = "Create a Token on GitHub Enterprise";
 
-"settings.github.login.header" = "Sign in to your GitHub Enterprise account";
+"settings.github.login.header" = "Sign in to your GitHub account";
 "settings.github.login.enter.token.personal" = "Enter your Personal Access Token";
 "settings.github.login.access.scopes" = "GitHub personal access tokens must have these scopes set:";
 "settings.github.login.access.public.key" = "admin:public_key";


### PR DESCRIPTION
## Summary

- fix the login view texts for GitHub and GitHub Enterprise accounts (the localizations were switched around)
- fix the login view windows closing then logged successfully
- improve the id generation for source control accounts by not only using the username but also a provider-specific string, so the same usernames at different providers don't count as identical accounts

## Changes Made

See above.

## TODO

None.

## Motivation

Fix the explained bugs.

## Testing

- looking at the localizations
- validating the views close when logging in with GitHub & GitLab
- adding multiple accounts at once with the same username (GitHub & GitLab)

## Screenshots/GIFs


## Checklist

Please ensure all of the following are completed before submitting the PR:

- [X] Code has been tested and verified.
- [ ] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully.
- [X] Code follows the project's coding guidelines and style.
- [X] The branch is up-to-date with the latest changes from the main branch.
- [ ] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): #500 

## Additional Notes

Closes #500 
