### PR TITLE
Implement basic git commit functionality

### DIFF
--- a/AuroraEditor/Base/NavigatorSidebar/Model/ProjectNavigator/ProjectNavigatorMenu.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/Model/ProjectNavigator/ProjectNavigatorMenu.swift
@@ -147,38 +147,11 @@ final class ProjectNavigatorMenu: NSMenu {
 
     /// Submenu for **Source Control** menu item.
     private func sourceControlMenu(item: Item) -> NSMenu {
-        let sourceControlMenu = NSMenu(
-            title: "Source Control"
-        )
-        sourceControlMenu.addItem(
-            withTitle: "Commit \"\(item.fileName)\"...",
-            action: nil,
-            keyEquivalent: ""
-        )
-        sourceControlMenu.addItem(
-            .separator()
-        )
-        sourceControlMenu.addItem(
-            menuItem(
-                "Discard Changes in \"\(item.fileName)\"...",
-                action: #selector(discardChangesInFile)
-            )
-        )
-        sourceControlMenu.addItem(
-            .separator()
-        )
-        sourceControlMenu.addItem(
-            withTitle: "Add Selected Files",
-            action: nil,
-            keyEquivalent: ""
-        )
-        sourceControlMenu.addItem(
-            withTitle: "Mark Selected Files as Resolved",
-            action: nil,
-            keyEquivalent: ""
-        )
-
-        return sourceControlMenu
+        guard let workspaceURL = workspace?.workspaceURL() else { fatalError("No workspace URL configured") } // TODO: Investigate more robust solutions
+        let menu = SourceControlRelatedMenu(sender: outlineView, workspaceURL: workspaceURL)
+        menu.item = item
+        menu.setupMenu()
+        return menu
     }
 
     /// Updates the menu for the selected item and hides it if no item is provided.
@@ -270,37 +243,6 @@ final class ProjectNavigatorMenu: NSMenu {
     @objc
     private func duplicate() {
         item?.duplicate()
-    }
-
-    // MARK: Source Control
-
-    @objc
-    private func commitFile() {
-
-    }
-
-    // TODO: Need to find a way to check for changes in the current selected file
-    @objc
-    private func discardChangesInFile() {
-        let alert = NSAlert()
-        alert.messageText = "Do you want to permanently discard all changes to \"\(item?.fileName ?? "")\"?"
-        alert.informativeText = "You can't undo this action"
-        alert.alertStyle = .critical
-        alert.addButton(withTitle: "Discard Changes")
-        alert.buttons.last?.hasDestructiveAction = true
-        alert.addButton(withTitle: "Cancel")
-        if alert.runModal() == .alertFirstButtonReturn {
-            do {
-                try gitClient?.discardFileChanges(url: (item?.url.path)!)
-            } catch {
-                Log.error("Error when trying to discard changes in file!")
-            }
-        }
-    }
-
-    @objc
-    private func addSelectedFiles() {
-
     }
 }
 

--- a/AuroraEditor/Base/NavigatorSidebar/Model/ProjectNavigator/ProjectNavigatorMenu.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/Model/ProjectNavigator/ProjectNavigatorMenu.swift
@@ -147,7 +147,10 @@ final class ProjectNavigatorMenu: NSMenu {
 
     /// Submenu for **Source Control** menu item.
     private func sourceControlMenu(item: Item) -> NSMenu {
-        guard let workspaceURL = workspace?.workspaceURL() else { fatalError("No workspace URL configured") } // TODO: Investigate more robust solutions
+        guard let workspaceURL = workspace?.workspaceURL() else {
+            // TODO: Investigate more robust solutions
+            fatalError("No workspace URL configured")
+        }
         let menu = SourceControlRelatedMenu(sender: outlineView, workspaceURL: workspaceURL)
         menu.item = item
         menu.setupMenu()

--- a/AuroraEditor/Base/NavigatorSidebar/Model/SourceControlNavigator/Changes/SourceControlMenu.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/Model/SourceControlNavigator/Changes/SourceControlMenu.swift
@@ -44,7 +44,7 @@ final class SourceControlMenu: NSMenu {
         return mItem
     }
 
-    private func setupMenu() {
+    func setupMenu() {
 
         let showInFinder = menuItem("Show in Finder", action: #selector(showInFinder))
         let revealInProjectNav = menuItem("Reveal in Project Navigator", action: nil)
@@ -52,14 +52,14 @@ final class SourceControlMenu: NSMenu {
         let openInTab = menuItem("Open in Tab", action: #selector(openInTab))
         let openInNewWindow = menuItem("Open in New Indow", action: nil)
         let openExternalEditor = menuItem("Open with External Editor", action: #selector(openWithExternalEditor))
+        
+        let sourceControlRelatedMenu = SourceControlRelatedMenu(sender: outlineView, workspaceURL: gitClient.directoryURL)
+        sourceControlRelatedMenu.item = item
+        sourceControlRelatedMenu.setupMenu()
+        
+        let sourceControl = menuItem("Source Control", action: nil)
+        setSubmenu(sourceControlRelatedMenu, for: sourceControl)
 
-        let commitFile = menuItem("Commit \"\(item?.fileName ?? "Selected Files")\"...", action: nil)
-
-        let discardChanges = menuItem("Discard Changes in \"\(item?.fileName ?? "Selected Files")\"...",
-                                      action: #selector(discardChangesInFile))
-
-        let addSelectedFiles = menuItem("Add Selected Files...", action: nil)
-        let markAsResolved = menuItem("Mark Selected Files as Resolved", action: nil)
 
         items = [
             showInFinder,
@@ -69,12 +69,7 @@ final class SourceControlMenu: NSMenu {
             openInNewWindow,
             openExternalEditor,
             NSMenuItem.separator(),
-            commitFile,
-            NSMenuItem.separator(),
-            discardChanges,
-            NSMenuItem.separator(),
-            addSelectedFiles,
-            markAsResolved
+            sourceControl
         ]
     }
 
@@ -110,29 +105,6 @@ final class SourceControlMenu: NSMenu {
 
     }
 
-    // TODO: Need to find a way to check for changes in the current selected file
-    @objc
-    private func discardChangesInFile() {
-        let alert = NSAlert()
-        alert.messageText = "Do you want to permanently discard all changes to \"\(item?.fileName ?? "")\"?"
-        alert.informativeText = "You can't undo this action"
-        alert.alertStyle = .critical
-        alert.addButton(withTitle: "Discard Changes")
-        alert.buttons.last?.hasDestructiveAction = true
-        alert.addButton(withTitle: "Cancel")
-        if alert.runModal() == .alertFirstButtonReturn {
-            do {
-                try gitClient.discardFileChanges(url: (item?.url.path)!)
-            } catch {
-                Log.error("Error when trying to discard changes in file!")
-            }
-        }
-    }
-
-    @objc
-    private func addSelectedFiles() {
-
-    }
 }
 
 extension NSMenuItem {

--- a/AuroraEditor/Base/NavigatorSidebar/Model/SourceControlNavigator/Changes/SourceControlMenu.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/Model/SourceControlNavigator/Changes/SourceControlMenu.swift
@@ -52,15 +52,15 @@ final class SourceControlMenu: NSMenu {
         let openInTab = menuItem("Open in Tab", action: #selector(openInTab))
         let openInNewWindow = menuItem("Open in New Indow", action: nil)
         let openExternalEditor = menuItem("Open with External Editor", action: #selector(openWithExternalEditor))
-        
-        let sourceControlRelatedMenu = SourceControlRelatedMenu(sender: outlineView, workspaceURL: gitClient.directoryURL)
+        let sourceControlRelatedMenu = SourceControlRelatedMenu(
+            sender: outlineView,
+            workspaceURL: gitClient.directoryURL
+        )
         sourceControlRelatedMenu.item = item
         sourceControlRelatedMenu.setupMenu()
-        
+
         let sourceControl = menuItem("Source Control", action: nil)
         setSubmenu(sourceControlRelatedMenu, for: sourceControl)
-
-
         items = [
             showInFinder,
             revealInProjectNav,

--- a/AuroraEditor/Base/NavigatorSidebar/Model/SourceControlNavigator/Changes/SourceControlRelatedMenu.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/Model/SourceControlNavigator/Changes/SourceControlRelatedMenu.swift
@@ -11,34 +11,34 @@ import Version_Control
 
 final class SourceControlRelatedMenu: NSMenu {
     typealias Item = FileItem
-    
+
     private let gitClient: GitClient
-    
+
     var item: Item?
-    
+
     var workspace: WorkspaceDocument?
-    
+
     private let fileManager = FileManager.default
-    
+
     private var outlineView: NSOutlineView
-    
+
     init(sender: NSOutlineView, workspaceURL: URL) {
         outlineView = sender
         gitClient = GitClient(directoryURL: workspaceURL, shellClient: sharedShellClient.shellClient)
         super.init(title: "Source Control Related Options")
     }
-    
+
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     private func menuItem(_ title: String, action: Selector?, key: String = "") -> NSMenuItem {
         let mItem = NSMenuItem(title: title, action: action, keyEquivalent: key)
         mItem.target = self
 
         return mItem
     }
-    
+
     func setupMenu() {
         let commitFile = menuItem("Commit \"\(item?.fileName ?? "Selected Files")\"...", action: nil)
 
@@ -48,7 +48,7 @@ final class SourceControlRelatedMenu: NSMenu {
         let addSelectedFiles = menuItem("Add Selected Files...", action: #selector(addSelectedFiles))
         let unstageSelectedFiles = menuItem("Unstage Selected Files...", action: #selector(unstageSelectedFiles))
         let markAsResolved = menuItem("Mark Selected Files as Resolved", action: nil)
-        
+
         items = [
             commitFile,
             discardChanges,
@@ -58,7 +58,7 @@ final class SourceControlRelatedMenu: NSMenu {
             markAsResolved
         ]
     }
-    
+
     // TODO: Need to find a way to check for changes in the current selected file
     @objc
     private func discardChangesInFile() {
@@ -83,7 +83,7 @@ final class SourceControlRelatedMenu: NSMenu {
         guard let fileName = item?.fileName else { return }
         try? gitClient.stage(files: [fileName])
     }
-    
+
     @objc private func unstageSelectedFiles() {
         guard let fileName = item?.fileName else { return }
         try? gitClient.unstage(files: [fileName])

--- a/AuroraEditor/Base/NavigatorSidebar/Model/SourceControlNavigator/Changes/SourceControlRelatedMenu.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/Model/SourceControlNavigator/Changes/SourceControlRelatedMenu.swift
@@ -1,0 +1,91 @@
+//
+//  SourceControlRelatedMenu.swift
+//  Aurora Editor
+//
+//  Created by Miguel Themann on 24.09.23.
+//  Copyright © 2023 Aurora Company. All rights reserved.
+//
+
+import SwiftUI
+import Version_Control
+
+final class SourceControlRelatedMenu: NSMenu {
+    typealias Item = FileItem
+    
+    private let gitClient: GitClient
+    
+    var item: Item?
+    
+    var workspace: WorkspaceDocument?
+    
+    private let fileManager = FileManager.default
+    
+    private var outlineView: NSOutlineView
+    
+    init(sender: NSOutlineView, workspaceURL: URL) {
+        outlineView = sender
+        gitClient = GitClient(directoryURL: workspaceURL, shellClient: sharedShellClient.shellClient)
+        super.init(title: "Source Control Related Options")
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func menuItem(_ title: String, action: Selector?, key: String = "") -> NSMenuItem {
+        let mItem = NSMenuItem(title: title, action: action, keyEquivalent: key)
+        mItem.target = self
+
+        return mItem
+    }
+    
+    func setupMenu() {
+        let commitFile = menuItem("Commit \"\(item?.fileName ?? "Selected Files")\"...", action: nil)
+
+        let discardChanges = menuItem("Discard Changes in \"\(item?.fileName ?? "Selected Files")\"...",
+                                      action: #selector(discardChangesInFile))
+
+        let addSelectedFiles = menuItem("Add Selected Files...", action: #selector(addSelectedFiles))
+        let unstageSelectedFiles = menuItem("Unstage Selected Files...", action: #selector(unstageSelectedFiles))
+        let markAsResolved = menuItem("Mark Selected Files as Resolved", action: nil)
+        
+        items = [
+            commitFile,
+            discardChanges,
+            NSMenuItem.separator(),
+            addSelectedFiles,
+            unstageSelectedFiles,
+            markAsResolved
+        ]
+    }
+    
+    // TODO: Need to find a way to check for changes in the current selected file
+    @objc
+    private func discardChangesInFile() {
+        let alert = NSAlert()
+        alert.messageText = "Do you want to permanently discard all changes to \"\(item?.fileName ?? "")\"?"
+        alert.informativeText = "You can't undo this action"
+        alert.alertStyle = .critical
+        alert.addButton(withTitle: "Discard Changes")
+        alert.buttons.last?.hasDestructiveAction = true
+        alert.addButton(withTitle: "Cancel")
+        if alert.runModal() == .alertFirstButtonReturn {
+            do {
+                try gitClient.discardFileChanges(url: (item?.url.path)!)
+            } catch {
+                Log.error("Error when trying to discard changes in file!")
+            }
+        }
+    }
+
+    @objc
+    private func addSelectedFiles() {
+        guard let fileName = item?.fileName else { return }
+        try? gitClient.stage(files: [fileName])
+    }
+    
+    @objc private func unstageSelectedFiles() {
+        guard let fileName = item?.fileName else { return }
+        try? gitClient.unstage(files: [fileName])
+    }
+}

--- a/AuroraEditor/Base/NavigatorSidebar/UI/SourceControlNavigator/Changes/CommitChangesView.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/UI/SourceControlNavigator/Changes/CommitChangesView.swift
@@ -20,7 +20,7 @@ struct CommitChangesView: View {
 
     @State
     var workspace: WorkspaceDocument
-    
+
     @State
     private var stageAll: Bool = false
 
@@ -118,11 +118,11 @@ struct CommitChangesView: View {
         guard let branchName = try? gitClient?.getCurrentBranchName() else { return "Not Available" }
         return branchName
     }
-    
+
     private func commit() {
         guard let client = gitClient else { Log.error("No git client!"); return } // TODO: Proper error handling.
         do {
-            let changedFiles = (try? client.getChangedFiles().map {$0.fileName}) ?? []
+            let changedFiles = (try? client.getChangedFiles().map { $0.fileName }) ?? []
             if !changedFiles.isEmpty {
                 if stageAll {
                     try client.stage(files: changedFiles)
@@ -135,7 +135,7 @@ struct CommitChangesView: View {
             } else {
                 Log.info("No changes to commit!")
             }
-        } catch (let err) {
+        } catch let err {
             Log.error(err)
         }
     }

--- a/AuroraEditor/Base/Version Control/Model/Client/Core/GitClient.swift
+++ b/AuroraEditor/Base/Version Control/Model/Client/Core/GitClient.swift
@@ -282,4 +282,31 @@ public class GitClient: ObservableObject {
             }
         }
     }
+    
+    public func stage(files: [String]) throws {
+        let output = try shellClient.run("cd \(directoryURL.relativePath.escapedWhiteSpaces());git add \(files.joined(separator: " "))")
+        if output.contains("fatal") {
+            throw GitClientError.outputError(output)
+        } else {
+            Log.info("Successfully staged files: \(files.joined(separator: ", "))")
+        }
+    }
+    
+    public func unstage(files: [String]) throws {
+        let output = try shellClient.run("cd \(directoryURL.relativePath.escapedWhiteSpaces());git restore --staged \(files.joined(separator: " "))")
+        if output.contains("fatal") {
+            throw GitClientError.outputError(output)
+        } else {
+            Log.info("Successfully unstaged files: \(files.joined(separator: ", "))")
+        }
+    }
+    
+    public func commit(message: String) throws {
+        let output = try shellClient.run("cd \(directoryURL.relativePath.escapedWhiteSpaces());git commit -m '\(message.escapedQuotes())'")
+        if output.contains("fatal") {
+            throw GitClientError.outputError(output)
+        } else {
+            Log.info("Successfully commited with message \"\(message)\"")
+        }
+    }
 }

--- a/AuroraEditor/Base/Version Control/Model/Client/Core/GitClient.swift
+++ b/AuroraEditor/Base/Version Control/Model/Client/Core/GitClient.swift
@@ -14,7 +14,7 @@ import Combine
 import Version_Control
 
 // A protocol to make calls to terminal to init a git call.
-public class GitClient: ObservableObject {
+public class GitClient: ObservableObject { // swiftlint:disable:this type_body_length
     var directoryURL: URL
     var shellClient: ShellClient
 
@@ -53,7 +53,8 @@ public class GitClient: ObservableObject {
 
     public func getCurrentBranchName() throws -> String {
         let output = try shellClient.run(
-            "cd \(directoryURL.relativePath.escapedWhiteSpaces());git rev-parse --abbrev-ref HEAD"
+            "cd \(directoryURL.relativePath.escapedWhiteSpaces());" +
+            "git rev-parse --abbrev-ref HEAD"
         )
             .replacingOccurrences(of: "\n", with: "")
         if output.contains("fatal: not a git repository") {
@@ -81,7 +82,8 @@ public class GitClient: ObservableObject {
     public func checkoutBranch(name: String) throws {
         guard currentBranchNameSubject.value != name else { return }
         let output = try shellClient.run(
-            "cd \(directoryURL.relativePath.escapedWhiteSpaces());git checkout \(name)"
+            "cd \(directoryURL.relativePath.escapedWhiteSpaces());" +
+            "git checkout \(name)"
         )
         if output.contains("fatal: not a git repository") {
             throw GitClientError.notGitRepository
@@ -282,27 +284,35 @@ public class GitClient: ObservableObject {
             }
         }
     }
-    
+
     public func stage(files: [String]) throws {
-        let output = try shellClient.run("cd \(directoryURL.relativePath.escapedWhiteSpaces());git add \(files.joined(separator: " "))")
+        let output = try shellClient.run(
+            "cd \(directoryURL.relativePath.escapedWhiteSpaces());git add \(files.joined(separator: " "))"
+        )
         if output.contains("fatal") {
             throw GitClientError.outputError(output)
         } else {
             Log.info("Successfully staged files: \(files.joined(separator: ", "))")
         }
     }
-    
+
     public func unstage(files: [String]) throws {
-        let output = try shellClient.run("cd \(directoryURL.relativePath.escapedWhiteSpaces());git restore --staged \(files.joined(separator: " "))")
+        let output = try shellClient.run(
+            "cd \(directoryURL.relativePath.escapedWhiteSpaces());" +
+            "git restore --staged \(files.joined(separator: " "))"
+        )
         if output.contains("fatal") {
             throw GitClientError.outputError(output)
         } else {
             Log.info("Successfully unstaged files: \(files.joined(separator: ", "))")
         }
     }
-    
+
     public func commit(message: String) throws {
-        let output = try shellClient.run("cd \(directoryURL.relativePath.escapedWhiteSpaces());git commit -m '\(message.escapedQuotes())'")
+        let output = try shellClient.run(
+            "cd \(directoryURL.relativePath.escapedWhiteSpaces());" +
+            "git commit -m '\(message.escapedQuotes())'"
+        )
         if output.contains("fatal") {
             throw GitClientError.outputError(output)
         } else {

--- a/AuroraEditor/Utils/Extensions/String.swift
+++ b/AuroraEditor/Utils/Extensions/String.swift
@@ -104,7 +104,7 @@ extension String {
     func escapedWhiteSpaces() -> String {
         self.replacingOccurrences(of: " ", with: "\\ ")
     }
-    
+
     /// Escape single quotes
     func escapedQuotes() -> String {
         return self.replacingOccurrences(of: "'", with: "\'")

--- a/AuroraEditor/Utils/Extensions/String.swift
+++ b/AuroraEditor/Utils/Extensions/String.swift
@@ -104,6 +104,11 @@ extension String {
     func escapedWhiteSpaces() -> String {
         self.replacingOccurrences(of: " ", with: "\\ ")
     }
+    
+    /// Escape single quotes
+    func escapedQuotes() -> String {
+        return self.replacingOccurrences(of: "'", with: "\'")
+    }
 
     func index(from: Int) -> Index {
         return self.index(self.startIndex, offsetBy: from)


### PR DESCRIPTION
## Summary

- implement context menus (NSMenus) for staging & unstaging files
- implement commit in CommitChangesView
- add 'Stage All'-toggle to stage all changes before committing
- refactor source-control-related functionality of NSMenus ProjectNavigatorMenu and SourceControlMenu into the reusable SourceControlRelatedMenu

## Changes Made

See above.

## TODO

None.

## Motivation

Being able to handle a full commit situation (local, not pushing anywhere)

## Testing

- stage files via context menu and inspect via git-CLI
- unstage and do the same (may need to alter file after staging so it appears as a single file in changes view)
- commit including description and inspect

## Screenshots/GIFs

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [X] Code has been tested and verified.
- [ ] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully.
- [X] Code follows the project's coding guidelines and style.
- [X] The branch is up-to-date with the latest changes from the main branch.
- [ ] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): None (directly).

## Additional Notes
