### PR TITLE
Fix version number on about screen, fixes #465

### DIFF
--- a/AuroraEditor/Base/About/UI/ApplicationsDetailsView.swift
+++ b/AuroraEditor/Base/About/UI/ApplicationsDetailsView.swift
@@ -45,7 +45,9 @@ struct ApplicationsDetailsView: View {
                 Text("Aurora Editor")
                     .font(.system(size: 24, weight: .regular))
 
-                Text("about.version \(appVersion) (\(appBuild))")
+                Text(
+                    "about.version".localized(appVersion, appBuild)
+                )
                     .textSelection(.enabled)
                     .foregroundColor(.secondary)
                     .font(.system(size: 12, weight: .light))

--- a/AuroraEditor/Localization/Localized+Ex.swift
+++ b/AuroraEditor/Localization/Localized+Ex.swift
@@ -25,4 +25,12 @@ extension String {
 
         return NSLocalizedString(self, bundle: bundle, comment: "")
     }
+
+    var localized: String {
+        return NSLocalizedString(self, comment: "\(self)_comment")
+    }
+
+    func localized(_ args: CVarArg...) -> String {
+        return String(format: localized, arguments: args)
+    }
 }


### PR DESCRIPTION
## Summary

Fix version number on about screen, fixes #465

## Changes Made

- Added helper function to parse arguments for localized strings.
- Fixed about window version display.

## TODO

None

## Motivation

Fixes #465 

## Testing

N/A

## Screenshots/GIFs

<img width="780" alt="image" src="https://github.com/AuroraEditor/AuroraEditor/assets/1290461/18eea2a5-9f53-44b6-b324-1823dfdcc6a6">

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [x] Code has been tested and verified.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully.
- [x] Code follows the project's coding guidelines and style.
- [x] The branch is up-to-date with the latest changes from the main branch.
- [x] Reviewed by at least one other contributor.

## Related Issues

#465

## Additional Notes

N/A