### PR TITLE
fixed non aligned theme icons

### DIFF
--- a/AuroraEditor/Base/AppPreferences/UI/ThemePreferences/ThemePreferencesView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/ThemePreferences/ThemePreferencesView.swift
@@ -109,7 +109,7 @@ public struct ThemePreferencesView: View {
     private var sidebarScrollView: some View {
         ScrollView {
             let grid: [GridItem] = .init(
-                repeating: .init(.fixed(130), spacing: 20, alignment: .center),
+                repeating: .init(.fixed(130), spacing: 20, alignment: .top),
                 count: 2
             )
             LazyVGrid(columns: grid,


### PR DESCRIPTION
## Summary

- Changes grid alignment from .center to .top to align theme icons horizontally
- Closes #481 

## Changes Made

Changes grid alignment from .center to .top to align theme icons horizontally

## Screenshots/GIFs

![image](https://github.com/AuroraEditor/AuroraEditor/assets/66741910/87fed8ef-b1a8-4a86-bda1-02d22ef032d7)

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [X] Code has been tested and verified.
- [ ] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully.
- [X] Code follows the project's coding guidelines and style.
- [X] The branch is up-to-date with the latest changes from the main branch.
- [ ] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): #481 

