### PR TITLE
Adds CursorStyles option for terminal

### DIFF
--- a/Aurora Editor.xcodeproj/project.pbxproj
+++ b/Aurora Editor.xcodeproj/project.pbxproj
@@ -5036,7 +5036,7 @@
 			repositoryURL = "https://github.com/migueldeicaza/SwiftTerm.git";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.7;
+				version = 1.2.0;
 			};
 		};
 		2BD0BD152977357900629A86 /* XCRemoteSwiftPackageReference "SwiftOniguruma" */ = {

--- a/AuroraEditor/Base/AppPreferences/Model/Terminal/TerminalPreferences.swift
+++ b/AuroraEditor/Base/AppPreferences/Model/Terminal/TerminalPreferences.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Aurora Company. All rights reserved.
 //
 
-import Foundation
+import SwiftTerm
 
 public extension AppPreferences {
 
@@ -24,6 +24,12 @@ public extension AppPreferences {
 
         /// The font to use in terminal.
         public var font: TerminalFont = .init()
+
+        /// The cursor style to apply on the terminal. Defaults to `block`.
+        public var cursorStyle: TerminalCursorStyle = .block
+
+        /// Boolean value for whether the cursor should blink.
+        public var blinkCursor: Bool = false
 
         /// Default initializer
         public init() {}
@@ -68,5 +74,16 @@ public extension AppPreferences {
             self.size = try container.decodeIfPresent(Int.self, forKey: .size) ?? 11
             self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? "SFMono-Medium"
         }
+    }
+
+    /// The possible terminal cursor shapes.
+    enum TerminalCursorStyle: String, Codable, CaseIterable, Identifiable {
+        public var id: String { rawValue }
+        /// Cursor appears as a block shape █
+        case block
+        /// Cursor appears as an underline _
+        case underline
+        /// Cursor appears as a vertical bar |
+        case verticalBar = "vertical bar"
     }
 }

--- a/AuroraEditor/Base/AppPreferences/UI/TerminalPreferences/TerminalPreferencesView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/TerminalPreferences/TerminalPreferencesView.swift
@@ -28,6 +28,10 @@ public struct TerminalPreferencesView: View {
                 fontSelector
                     .padding(.horizontal)
                     .padding(.bottom, 5)
+                Divider()
+                cursorSelector
+                    .padding(.horizontal)
+                    .padding(.bottom, 5)
             }
         }
     }
@@ -76,6 +80,26 @@ public struct TerminalPreferencesView: View {
                     "\(prefs.preferences.terminal.font.name) \(prefs.preferences.terminal.font.size)",
                     name: $prefs.preferences.terminal.font.name, size: $prefs.preferences.terminal.font.size
                 )
+            }
+        }
+    }
+
+    private var cursorSelector: some View {
+        HStack(alignment: .top) {
+            Text("Cursor")
+            Spacer()
+            VStack(alignment: .trailing) {
+                Picker("", selection: $prefs.preferences.terminal.cursorStyle) {
+                    ForEach(AppPreferences.TerminalCursorStyle.allCases) { style in
+                        Text(style.rawValue.capitalized)
+                            .tag(style)
+                    }
+                }
+                .pickerStyle(.radioGroup)
+                Spacer()
+                HStack {
+                    Toggle("Blink cursor", isOn: $prefs.preferences.terminal.blinkCursor)
+                }
             }
         }
     }

--- a/AuroraEditor/Base/TerminalEmulator/UI/TerminalEmulatorView.swift
+++ b/AuroraEditor/Base/TerminalEmulator/UI/TerminalEmulatorView.swift
@@ -182,6 +182,9 @@ public struct TerminalEmulatorView: NSViewRepresentable {
         }
         terminal.appearance = colorAppearance
         scroller?.isHidden = true
+        terminal.getTerminal().setCursorStyle(
+            getCursorStyle(prefs.preferences.terminal.cursorStyle, shouldBlink: prefs.preferences.terminal.blinkCursor)
+        )
         TerminalEmulatorView.lastTerminal[url.path] = terminal
     }
 
@@ -211,9 +214,23 @@ public struct TerminalEmulatorView: NSViewRepresentable {
         }
         view.getTerminal().softReset()
         view.feed(text: "") // send empty character to force colors to be redrawn
+        view.getTerminal().setCursorStyle(
+            getCursorStyle(prefs.preferences.terminal.cursorStyle, shouldBlink: prefs.preferences.terminal.blinkCursor)
+        )
     }
 
     public func makeCoordinator() -> Coordinator {
         Coordinator(url: url)
+    }
+
+    private func getCursorStyle(_ style: AppPreferences.TerminalCursorStyle, shouldBlink: Bool) -> CursorStyle {
+        switch style {
+        case .block:
+            return shouldBlink ? .blinkBlock : .steadyBlock
+        case .underline:
+            return shouldBlink ? .blinkUnderline : .steadyUnderline
+        case .verticalBar:
+            return shouldBlink ? .blinkBar : .steadyBar
+        }
     }
 }


### PR DESCRIPTION
## Summary

Luckily in version [1.2.0](https://github.com/migueldeicaza/SwiftTerm/commit/131a52bf3b1e9e8f8ed8d8298d3112972eb9ce22) of `SwiftTerm`, they’ve introduced `CursorStyle` which provides multiple styles for the cursor. In issue https://github.com/AuroraEditor/AuroraEditor/issues/482, it was mentioned that currently the cursor blocks visibility of a character when going over it. Therefore, by introducing cursor styles, the user can now choose their preference of shape as well as whether they'd like it to blink or not allowing them to see the character behind the cursor.

## Screenshots/GIFs

![CleanShot 2023-10-16 at 23 12 51](https://github.com/AuroraEditor/AuroraEditor/assets/36312970/d6170bd4-7a9a-4bb1-b3a5-e2e28d2649c9)

<img width="500" alt="CleanShot 2023-10-16 at 23 10 17@2x" src="https://github.com/AuroraEditor/AuroraEditor/assets/36312970/9ca8a162-8bb6-4965-852c-5475507f6878">


## Checklist

Please ensure all of the following are completed before submitting the PR:

- [x] Code has been tested and verified.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully.
- [x] Code follows the project's coding guidelines and style.
- [x] The branch is up-to-date with the latest changes from the main branch.
- [ ] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): https://github.com/AuroraEditor/AuroraEditor/issues/482

