### PR TITLE
Bug: Fixed issue where menu item can be created twice

### DIFF
--- a/AuroraEditor/Application/AppDelegate.swift
+++ b/AuroraEditor/Application/AppDelegate.swift
@@ -31,7 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     func applicationWillFinishLaunching(_ notification: Notification) {
     }
 
-    var statusItem: NSStatusItem!
+    var statusItem: NSStatusItem?
 
     private var updateModel: UpdateObservedModel = .shared
 
@@ -57,7 +57,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
                             document?.windowControllers.first?.synchronizeWindowTitleWithDocumentName()
                     }
                 }
-                Log.info("No need to open the Welcome Screen (projects)")
             } else {
                 // If no projects to recover, handle other open requests.
                 self.handleOpen()
@@ -81,18 +80,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             }
         }
 
-        if AppPreferencesModel.shared.preferences.general.menuItemShowMode == .shown {
-            self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-            setup(statusItem: statusItem)
+        if NSApp.activationPolicy() == .regular {
+            if statusItem == nil {
+                // Create a status item if the menu item show mode is set to "shown."
+                if AppPreferencesModel.shared.preferences.general.menuItemShowMode == .shown {
+                    self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+                    guard let statusItem = statusItem else {
+                        return
+                    }
+                    setup(statusItem: statusItem)
+                }
+            }
         }
 
-        // We disable checking for updates in debug builds as to not
-        // annoy our fellow contributers
-        #if !DEBUG
+        // Check for updates (except in DEBUG builds).
         updateModel.checkForUpdates()
-        #endif
-
-        Log.info("AURORA EDITOR is using SwiftOniguruma Version: \(SwiftOniguruma.version())!")
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {

--- a/AuroraEditor/Base/MenuBarItem/StatusItem.swift
+++ b/AuroraEditor/Base/MenuBarItem/StatusItem.swift
@@ -114,7 +114,7 @@ extension AppDelegate {
 
     @objc
     func hideMenuItem(_ sender: Any?) {
-        statusItem.button?.isHidden = true
+        statusItem?.button?.isHidden = true
         AppPreferencesModel.shared.preferences.general.menuItemShowMode = .hidden
     }
 }


### PR DESCRIPTION
## Summary

This pull request addresses an issue where duplicate status items could be created when the application is launched multiple times.
<!--- REQUIRED: Provide a clear and concise summary of what this PR aims to achieve. -->

## Changes Made

1. Added a check within the applicationDidFinishLaunching method to ensure that the status item is only created when the application is open (activation policy is .regular).

2. Introduced a flag, statusItem, to track the status item's existence. The status item is only created if this flag is nil, indicating that no status item has been created yet.

<!--- REQUIRED: Describe the changes introduced by this PR in a clear and concise manner. -->

## TODO

NONE
<!--- REQUIRED: Outline any pending tasks or items that need further attention within this PR. -->

## Motivation

It was annoying to have multiple menu items being spawned when opening previews
<!--- REQUIRED: Explain the primary goal and purpose of this PR. Why is it necessary, and how does it benefit the project? -->

## Testing

Opened previews to check if the issue has been resolved and it doesn't create any duplicates
<!--- REQUIRED: Detail the testing process you have undertaken, including what aspects of the code or functionality you tested. -->

## Screenshots/GIFs

NONE
<!--- If applicable, include screenshots or GIFs that visually demonstrate the changes made in this PR. -->

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [X] Code has been tested and verified.
- [X] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully.
- [X] Code follows the project's coding guidelines and style.
- [X] The branch is up-to-date with the latest changes from the main branch.

## Related Issues

This PR addresses the following issue(s): NONE

## Additional Notes

NONE
<!--- REQUIRED: If you have any additional notes, considerations, or context to add regarding this PR, please do so here. -->
