### PR TITLE
Extension support title on notification + notification size changes

### DIFF
--- a/AuroraEditor/Base/Documents/UI/WorkspaceView.swift
+++ b/AuroraEditor/Base/Documents/UI/WorkspaceView.swift
@@ -153,23 +153,29 @@ struct WorkspaceView: View {
                 if command.name == "openSettings" {
                     workspace.windowController?.openSettings()
                 }
-                if command.name == "showNotification",
-                   let message = command.parameters["message"] as? String {
-                    notificationService.notify(notification: INotification(
-                                            id: UUID().uuidString,
-                                            severity: .info,
-                                            title: "",
-                                            message: message,
-                                            notificationType: .extensionSystem,
-                                            silent: false))
+                if command.name == "showNotification" {
+                    notificationService.notify(
+                        notification: INotification(
+                            id: UUID().uuidString,
+                            severity: .info,
+                            title: (command.parameters["title"] as? String) ?? "",
+                            message: (command.parameters["message"] as? String) ?? "",
+                            notificationType: .extensionSystem,
+                            silent: false
+                        )
+                    )
                 }
-                if command.name == "showWarning",
-                   let message = command.parameters["message"] as? String {
-                    notificationService.warn(title: "", message: message)
+                if command.name == "showWarning" {
+                    notificationService.warn(
+                        title: (command.parameters["title"] as? String) ?? "",
+                        message: (command.parameters["message"] as? String) ?? ""
+                    )
                 }
-                if command.name == "showError",
-                   let message = command.parameters["message"] as? String {
-                    notificationService.error(title: "", message: message)
+                if command.name == "showError" {
+                    notificationService.error(
+                        title: (command.parameters["title"] as? String) ?? "",
+                        message: (command.parameters["message"] as? String) ?? ""
+                    )
                 }
                 if command.name == "openSheet",
                    let view = command.parameters["view"] as? any View {

--- a/AuroraEditor/Base/Notification/UI/NotificationToastView.swift
+++ b/AuroraEditor/Base/Notification/UI/NotificationToastView.swift
@@ -27,11 +27,9 @@ struct NotificationToastView: View {
                     .frame(maxWidth: 24, maxHeight: 24)
 
                 // Notification source or identifier.
-                if !notification.title.isEmpty {
-                    Text(notification.title)
-                        .fontWithLineHeight(fontSize: 12, lineHeight: 7)
-                        .foregroundColor(.secondary)
-                }
+                Text(notification.title)
+                    .fontWithLineHeight(fontSize: 12, lineHeight: 7)
+                    .foregroundColor(.secondary)
 
                 Spacer()
 

--- a/AuroraEditor/Base/Notification/UI/NotificationToastView.swift
+++ b/AuroraEditor/Base/Notification/UI/NotificationToastView.swift
@@ -24,15 +24,18 @@ struct NotificationToastView: View {
             HStack(alignment: .center) {
                 // Notification icon.
                 NotificationIcon(notification: notification)
+                    .frame(maxWidth: 24, maxHeight: 24)
 
                 // Notification source or identifier.
-                Text("Docker")
-                    .fontWithLineHeight(fontSize: 12, lineHeight: 7)
-                    .foregroundColor(.secondary)
+                if !notification.title.isEmpty {
+                    Text(notification.title)
+                        .fontWithLineHeight(fontSize: 12, lineHeight: 7)
+                        .foregroundColor(.secondary)
+                }
 
                 Spacer()
 
-                // Timestamp for when the notification was received.
+                // TODO: Timestamp for when the notification was received.
                 Text("Now")
                     .fontWithLineHeight(fontSize: 11, lineHeight: 7)
                     .foregroundColor(.secondary)
@@ -41,17 +44,12 @@ struct NotificationToastView: View {
                 if model.hoveringOnToast {
                     Image(systemName: "xmark")
                         .font(.system(size: 11))
+                        .frame(maxWidth: 24, maxHeight: 24)
                         .onTapGesture {
                             model.showNotificationToast = false
                         }
                 }
             }
-
-            // Title of the notification.
-            Text(notification.title)
-                .fontWithLineHeight(fontSize: 13, lineHeight: 8)
-                .foregroundColor(.primary)
-                .padding(.top, 10)
 
             // Message content of the notification.
             Text(notification.message)
@@ -59,8 +57,8 @@ struct NotificationToastView: View {
                 .fontWithLineHeight(fontSize: 13, lineHeight: 8)
                 .foregroundColor(.secondary)
         }
-        .padding(10)
-        .frame(width: 350, height: 105)
+        .padding(.horizontal, 10)
+        .frame(minWidth: 350, minHeight: 75)
         .background(colorScheme == .light ? .white : Color(hex: "#252525"))
         .cornerRadius(8)
         .shadow(radius: 1)


### PR DESCRIPTION
## Summary

Add support for titles in notifications

## Changes Made
 
- Edited notification size (minimum sizes, fixed sizes for images)
- Changed placeholder title "Docker" to the title.
- Add support for receiving titles from extension notifications

## TODO

None

## Motivation

Extensions should be able to use custom titles.

## Testing

Used a test extension to fire notifications.


```swift
self.AuroraAPI(
    "showNotification",
    [
        "title":"showNotification",
        "message": "Waiting for 4 seconds..."
    ]
)
```
## Screenshots/GIFs

<img width="1110" alt="image" src="https://github.com/AuroraEditor/AuroraEditor/assets/1290461/f3ac89bf-6e46-472c-b553-c5f113112fae">

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [x] Code has been tested and verified.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully.
- [x] Code follows the project's coding guidelines and style.
- [x] The branch is up-to-date with the latest changes from the main branch.
- [x] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): None

## Additional Notes

None