### PR TITLE
Make navigator button non-focusable, fixes #609

### DIFF
--- a/AuroraEditor/Base/NavigatorSidebar/UI/NavigatorSidebarToolbar.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/UI/NavigatorSidebarToolbar.swift
@@ -70,6 +70,7 @@ struct NavigatorSidebarToolbar: View {
                 )
             }
             .id(icon.id)
+            .focusable(false)
             .buttonStyle(NavigatorToolbarButtonStyle(id: icon.id, selection: selection, activeState: activeState))
             .imageScale(.medium)
             .opacity(model.draggingItem?.imageName == icon.imageName &&

--- a/AuroraEditor/Base/NavigatorSidebar/UI/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/UI/ProjectNavigator/ProjectNavigatorToolbarBottom.swift
@@ -28,6 +28,7 @@ struct ProjectNavigatorToolbarBottom: View {
                 .padding(.leading, 10)
             HStack {
                 sortButton
+                    .padding(.leading, 5)
                 TextField("Filter", text: $filter)
                     .textFieldStyle(.plain)
                     .font(.system(size: 12))


### PR DESCRIPTION
## Summary

Fixes the buttons being focusable (accent color outline), and the filter icon

## Changes Made

- Navigator buttons non-focusable
- Padding of the filter icon

## TODO

None

## Motivation

@Angelk90 - https://discord.com/channels/997410333348077620/997418693472555130/1172806077063118959

## Testing

N/A

## Screenshots/GIFs

<img width="1110" alt="image" src="https://github.com/AuroraEditor/AuroraEditor/assets/1290461/95c3f8e9-2cac-4d61-8714-a6285d757ee7">

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [x] Code has been tested and verified.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully.
- [x] Code follows the project's coding guidelines and style.
- [x] The branch is up-to-date with the latest changes from the main branch.
- [x] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): #609

## Additional Notes

None.