### PR TITLE
Open notification pane when clicking on a notification badge

### DIFF
--- a/.github/workflows/sonarbuild.yml
+++ b/.github/workflows/sonarbuild.yml
@@ -6,8 +6,9 @@ on:
       - development
 
 jobs:
-  build:
-    name: Build
+  SonarBuild:
+    name: SonarBuild
+    if: github.repository_owner == 'AuroraEditor'
     runs-on: ubuntu-latest
     timeout-minutes: 10 # If a action exceeds 10 mins, it probably isn't ever going to complete.
     permissions: read-all

--- a/AuroraEditor/Base/NavigatorSidebar/UI/NavigatorSidebar.swift
+++ b/AuroraEditor/Base/NavigatorSidebar/UI/NavigatorSidebar.swift
@@ -45,6 +45,17 @@ struct NavigatorSidebar: View {
         })
         .padding(.top, prefs.preferences.general.sidebarStyle == .xcode ? 30 : 0)
         .padding(.leading, prefs.preferences.general.sidebarStyle == .vscode ? 30 : 0)
+        .onAppear {
+            NotificationCenter.default.addObserver(
+                forName: Notification.Name("changeNavigatorPane"),
+                object: nil,
+                queue: OperationQueue.main
+            ) { (notification) in
+                if let pane = notification.object as? Int {
+                    self.selections = [pane]
+                }
+            }
+        }
     }
 
     // swiftlint:disable:next function_body_length

--- a/AuroraEditor/Base/Notification/UI/ToolbarNotificationButtonView.swift
+++ b/AuroraEditor/Base/Notification/UI/ToolbarNotificationButtonView.swift
@@ -19,7 +19,10 @@ struct ToolbarNotificationButtonView: View {
 
     var body: some View {
         Button {
-            // Action to be performed when the button is tapped.
+            NotificationCenter.default.post(
+                name: Notification.Name("changeNavigatorPane"),
+                object: 5
+            )
         } label: {
             HStack {
                 // Display the notification icon based on severity.


### PR DESCRIPTION
## Summary

Open notification pane when clicking on a notification badge

## Changes Made

- Added a notification receiver in the Navigator Pane
- Added a notification sender in the Toolbar button

## TODO

None

## Motivation

Fixes the weird behaviour.

## Testing

None.

## Screenshots/GIFs

https://github.com/AuroraEditor/AuroraEditor/assets/1290461/8fa5cf39-734f-4ed9-b893-a52fd2b299de

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [x] Code has been tested and verified.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully.
- [x] Code follows the project's coding guidelines and style.
- [x] The branch is up-to-date with the latest changes from the main branch.
- [x] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): #575 

## Additional Notes

None