### PR TITLE
Fixed About UI padding & added Install Path & various typos

### DIFF
--- a/AuroraEditor/Base/About/UI/ApplicationsDetailsView.swift
+++ b/AuroraEditor/Base/About/UI/ApplicationsDetailsView.swift
@@ -82,7 +82,7 @@ struct ApplicationsDetailsView: View {
                     .background(aboutDetailState == .license ? Color(nsColor: NSColor(.accentColor)) : .clear)
                     .cornerRadius(20)
 
-                Text("about.contributers")
+                Text("about.contributors")
                     .onTapGesture {
                         aboutDetailState = .contributers
                     }

--- a/AuroraEditor/Base/About/UI/CreditsDetailView.swift
+++ b/AuroraEditor/Base/About/UI/CreditsDetailView.swift
@@ -15,6 +15,7 @@ struct CreditsDetailView: View {
                 .multilineTextAlignment(.leading)
                 .font(.system(size: 11))
         }
+        .frame(height: 300)
     }
 }
 

--- a/AuroraEditor/Base/About/UI/LicenseDetailView.swift
+++ b/AuroraEditor/Base/About/UI/LicenseDetailView.swift
@@ -15,7 +15,7 @@ public struct LicenseDetailView: View {
                 .multilineTextAlignment(.leading)
                 .font(.system(size: 11))
         }
-        .frame(height: 370)
+        .frame(height: 300)
     }
 }
 

--- a/AuroraEditor/Base/AppPreferences/UI/GeneralPreferences/GeneralPreferencesView.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/GeneralPreferences/GeneralPreferencesView.swift
@@ -132,6 +132,9 @@ public struct GeneralPreferencesView: View {
                     Divider()
                     preferencesLocation
                         .padding(.vertical, 5)
+                    Divider()
+                    installPathLocation
+                        .padding(.vertical, 5)
                 }
                 .padding(.bottom)
             }

--- a/AuroraEditor/Base/AppPreferences/UI/GeneralPreferences/GeneralPreferencesViewSections.swift
+++ b/AuroraEditor/Base/AppPreferences/UI/GeneralPreferences/GeneralPreferencesViewSections.swift
@@ -299,6 +299,40 @@ extension GeneralPreferencesView {
           .padding(.horizontal)
     }
 
+    var installPath: String {
+        var bundleURL = Bundle.main.resourceURL
+        guard var bundleURL = bundleURL?.deletingLastPathComponent() else {
+            return "No install path found"
+        }
+        bundleURL = bundleURL.deletingLastPathComponent()
+        return bundleURL.path // ?? "No install path found"
+    }
+
+    var installPathLocation: some View {
+        HStack {
+              Text("Install Path")
+              Spacer()
+              HStack {
+                  Text(self.installPath)
+                      .foregroundColor(.secondary)
+                  if let resPath = Bundle.main.resourcePath {
+                      Button {
+                          NSWorkspace.shared.selectFile(
+                            nil,
+                            inFileViewerRootedAtPath: resPath
+                          )
+                      } label: {
+                          Image(systemName: "arrow.right.circle.fill")
+                      }
+                      .buttonStyle(.plain)
+                      .foregroundColor(.secondary)
+                  }
+              }
+        }
+          .padding(.top, 5)
+          .padding(.horizontal)
+    }
+
     var revealFileOnFocusChangeToggle: some View {
         HStack {
             Text("settings.general.show.active.file")

--- a/AuroraEditor/Localization/af.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/af.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/cs.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/cs.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/cy.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/cy.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/da.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/da.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/de.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/de.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/el.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/el.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/en-001.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/en-001.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/en.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/en.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/es.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/es.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/fi.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/fi.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/fil.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/fil.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/fr.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/fr.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/ga.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ga.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/hi.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/hi.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/hr.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/hr.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/it.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/it.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/ja.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ja.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/ms.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ms.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/mt.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/mt.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/nb.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/nb.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/ne.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ne.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/nl.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/nl.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/pl.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/pl.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/pt-PT.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/pt-PT.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/ro.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ro.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/ru.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/ru.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/sv.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/sv.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/th-TH.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/th-TH.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/th.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/th.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/tn.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/tn.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/uk.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/uk.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/vi.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/vi.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/xh-ZA.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/xh-ZA.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/zh-HK.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zh-HK.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zh-Hans.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/zh-Hant.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zh-Hant.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";

--- a/AuroraEditor/Localization/zu-ZA.lproj/Localizable.strings
+++ b/AuroraEditor/Localization/zu-ZA.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 "about.no.hash" = "No Hash";
 "about.version" = "Version %@ (%@)";
 "about.license" = "License";
-"about.contributers" = "Contributers";
+"about.contributors" = "Contributors";
 "about.credits" = "Credits";
 
 "about.error.no.credits" = "Could not load credits for Aurora Editor.";


### PR DESCRIPTION
## Summary

Various typos as well as slight, non-impactful design changes are made.

## Changes Made

This PR:
- completes the "Contributer" -> "Contributor" typo fix in the About UI
- creates a new entry in GeneralPreferences that displays the install path of AE
- adds padding to About UI subviews for visual appeal

## TODO

*N/A*

## Motivation

These changes contribute to the overall design of the product.

## Testing

Test build, but these changes are not code-breaking.

## Screenshots/GIFs

**About UI Padding**

<img width="438" alt="About UI Padding" src="https://github.com/AuroraEditor/AuroraEditor/assets/91710711/88d768e6-c0dd-43ae-9bbe-b5904b422b28">


**Install Path**

<img width="583" alt="Install Path" src="https://github.com/AuroraEditor/AuroraEditor/assets/91710711/91c922a2-c444-49f6-88d7-7479cb86435b">


**Typo Fix**

<img width="103" alt="Typo Fix" src="https://github.com/AuroraEditor/AuroraEditor/assets/91710711/07d5e3a5-0812-40c7-8c38-256b290ad93e">

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [ ] Code has been tested and verified.
- [ ] Documentation has been updated to reflect the changes.
- [ ] All tests pass successfully.
- [x] Code follows the project's coding guidelines and style.
- [x] The branch is up-to-date with the latest changes from the main branch.
- [ ] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): [<!--- REQUIRED: Issue Number-->]

## Additional Notes

*N/A*