### PR TITLE
JavaScript extension support

### DIFF
--- a/Aurora Editor.xcodeproj/project.pbxproj
+++ b/Aurora Editor.xcodeproj/project.pbxproj
@@ -438,6 +438,8 @@
 		2B6CB09E2AFFA3B1001E4955 /* AEUpdateService.app in Resources */ = {isa = PBXBuildFile; fileRef = A01AB2D12ACC9EDA0029EDF0 /* AEUpdateService.app */; };
 		2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* AppDelegate.swift */; };
 		2B7AC06B282452FB0082A5B8 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B7AC06A282452FB0082A5B8 /* Media.xcassets */; };
+		2B7C8CC62BC5B3160061DE0D /* JSSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7C8CC52BC5B3160061DE0D /* JSSupport.swift */; };
+		2B7C8CC92BC5B3A10061DE0D /* AuroraJSSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7C8CC72BC5B3440061DE0D /* AuroraJSSupportTests.swift */; };
 		2B89F85428B13E9D007CB9C1 /* AuroraMessageBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B89F85328B13E9D007CB9C1 /* AuroraMessageBox.swift */; };
 		2BCBAAC82927C41E00D4DFB2 /* BindingProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCBAAC72927C41E00D4DFB2 /* BindingProxy.swift */; };
 		2BCBAACA2927C65500D4DFB2 /* View+isHidden.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCBAAC92927C65500D4DFB2 /* View+isHidden.swift */; };
@@ -1117,6 +1119,8 @@
 		2B5CAC812B87E701006B6C66 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		2B71C0A32874AD61008E0859 /* AuroraProject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuroraProject.swift; sourceTree = "<group>"; };
 		2B7AC06A282452FB0082A5B8 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
+		2B7C8CC52BC5B3160061DE0D /* JSSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSSupport.swift; sourceTree = "<group>"; };
+		2B7C8CC72BC5B3440061DE0D /* AuroraJSSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuroraJSSupportTests.swift; sourceTree = "<group>"; };
 		2B89F85328B13E9D007CB9C1 /* AuroraMessageBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuroraMessageBox.swift; sourceTree = "<group>"; };
 		2BCBAAC72927C41E00D4DFB2 /* BindingProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingProxy.swift; sourceTree = "<group>"; };
 		2BCBAAC92927C65500D4DFB2 /* View+isHidden.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+isHidden.swift"; sourceTree = "<group>"; };
@@ -2086,6 +2090,7 @@
 				20D837BE289A7ACD00D91D05 /* ExtensionsManager.swift */,
 				20D837C2289A7ACD00D91D05 /* Plugin.swift */,
 				20D837C0289A7ACD00D91D05 /* PluginRelease.swift */,
+				2B7C8CC52BC5B3160061DE0D /* JSSupport.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3193,6 +3198,7 @@
 			isa = PBXGroup;
 			children = (
 				2B11FF892AB0E8F4005B649C /* AuroraINITests.swift */,
+				2B7C8CC72BC5B3440061DE0D /* AuroraJSSupportTests.swift */,
 				2B53D1FB2B77A2250064114F /* AuroraEditorConfigTests.swift */,
 			);
 			path = "Aurora EditorTests";
@@ -4086,6 +4092,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2B7C8CC92BC5B3A10061DE0D /* AuroraJSSupportTests.swift in Sources */,
 				2B53D1FC2B77A2250064114F /* AuroraEditorConfigTests.swift in Sources */,
 				2B11FF8A2AB0E8F4005B649C /* AuroraINITests.swift in Sources */,
 			);
@@ -4565,6 +4572,7 @@
 				93D5F5D328CE064700286EBD /* TabHierarchyView.swift in Sources */,
 				93D5F5D528CE074100286EBD /* TabHierarchyViewController.swift in Sources */,
 				2B04575128E6FFE300024F2D /* TabStopsThemeAttribute.swift in Sources */,
+				2B7C8CC62BC5B3160061DE0D /* JSSupport.swift in Sources */,
 				2B04574F28E6FFE300024F2D /* TailIndentThemeAttribute.swift in Sources */,
 				9362B21628EC734200523626 /* TerminalColors.swift in Sources */,
 				2093CC9D289AA001003A88DD /* TerminalEmulatorView+Coordinator.swift in Sources */,

--- a/Aurora EditorTests/AuroraJSSupportTests.swift
+++ b/Aurora EditorTests/AuroraJSSupportTests.swift
@@ -10,10 +10,11 @@ import XCTest
 @testable import AuroraEditor
 
 final class AuroraJSSupportTests: XCTestCase {
-    let jsSupport = JSSupport(workspace: nil)
+    let jsSupport = JSSupport(name: "AEXCTestCase", path: "/", workspace: nil)
 
+    /// Test api access, using evaluate.
     func testJSAPIUsingEvaluate() throws {
-        guard let value = jsSupport.evaluate(
+        guard let value = jsSupport?.evaluate(
             script: "AuroraEditor.api('AuroraEditor.api using evaluate...');"
         ), value.toBool() else {
             XCTFail("Error: No value returned.")
@@ -21,8 +22,9 @@ final class AuroraJSSupportTests: XCTestCase {
         }
     }
 
-    func testJSAPIAPIUsingRespondToApi() {
-        guard let value = jsSupport.respondToAE(
+    /// Respond to AE using respondToAE()
+    func testJSAPIUsingRespondToApi() {
+        guard let value = jsSupport?.respondToAE(
             action: "api",
             parameters: ["api": "api using respondToAE()"]
         ), value.toBool() else {
@@ -31,9 +33,10 @@ final class AuroraJSSupportTests: XCTestCase {
         }
     }
 
-    func testJSAPIAPIUsingRespondToCustomApi() {
-        guard let script = jsSupport.evaluate(script: "function AEapiTest(v) { return v }"),
-              let value = jsSupport.respond(
+    /// Create a "custom" function, and run that custom function.
+    func testJSAPIUsingRespondToCustomApi() {
+        guard let script = jsSupport?.evaluate(script: "function AEapiTest(v) { return v }"),
+              let value = jsSupport?.respond(
                 action: "AEapiTest",
                 parameters: ["val": "api using respond()"]
               ), value.toString() == "api using respond()" else {
@@ -42,8 +45,9 @@ final class AuroraJSSupportTests: XCTestCase {
         }
     }
 
+    /// Evaluate `AuroraEditor.respond('func', {'some': 'value', 'dict':'ionary'});`
     func testJSAPIUsingRespondUsingEvaluate() {
-        guard let value = jsSupport.evaluate(
+        guard let value = jsSupport?.evaluate(
             script: "AuroraEditor.respond('func', {'some': 'value', 'dict':'ionary'});"
         ), value.toBool() else {
             XCTFail("Error: No value returned.")
@@ -51,8 +55,9 @@ final class AuroraJSSupportTests: XCTestCase {
         }
     }
 
-    func testJSAPIWhichShouldFailToReturn() {
-        guard let value = jsSupport.evaluate(
+    /// Execute a JavaScript code wich should fail to execute
+    func testJSAPIWhichShouldFailToExecute() {
+        guard let value = jsSupport?.evaluate(
             script: "this.should.fail();"
         ), !value.toBool() else {
             XCTFail("Error: value returned.")

--- a/Aurora EditorTests/AuroraJSSupportTests.swift
+++ b/Aurora EditorTests/AuroraJSSupportTests.swift
@@ -1,0 +1,62 @@
+//
+//  AuroraJSSupportTests.swift
+//  Aurora Editor
+//
+//  Created by Wesley de Groot on 09/04/2024.
+//  Copyright © 2024 Aurora Company. All rights reserved.
+//
+
+import XCTest
+@testable import AuroraEditor
+
+final class AuroraJSSupportTests: XCTestCase {
+    let jsSupport = JSSupport(workspace: nil)
+
+    func testJSAPIUsingEvaluate() throws {
+        guard let value = jsSupport.evaluate(
+            script: "AuroraEditor.api('AuroraEditor.api using evaluate...');"
+        ), value.toBool() else {
+            XCTFail("Error: No value returned.")
+            return
+        }
+    }
+
+    func testJSAPIAPIUsingRespondToApi() {
+        guard let value = jsSupport.respondToAE(
+            action: "api",
+            parameters: ["api": "api using respondToAE()"]
+        ), value.toBool() else {
+            XCTFail("Error: No value returned.")
+            return
+        }
+    }
+
+    func testJSAPIAPIUsingRespondToCustomApi() {
+        guard let script = jsSupport.evaluate(script: "function AEapiTest(v) { return v }"),
+              let value = jsSupport.respond(
+                action: "AEapiTest",
+                parameters: ["val": "api using respond()"]
+              ), value.toString() == "api using respond()" else {
+            XCTFail("Error: No value returned.")
+            return
+        }
+    }
+
+    func testJSAPIUsingRespondUsingEvaluate() {
+        guard let value = jsSupport.evaluate(
+            script: "AuroraEditor.respond('func', {'some': 'value', 'dict':'ionary'});"
+        ), value.toBool() else {
+            XCTFail("Error: No value returned.")
+            return
+        }
+    }
+
+    func testJSAPIWhichShouldFailToReturn() {
+        guard let value = jsSupport.evaluate(
+            script: "this.should.fail();"
+        ), !value.toBool() else {
+            XCTFail("Error: value returned.")
+            return
+        }
+    }
+}

--- a/AuroraEditor/Base/Documents/Model/WorkspaceDocument/WorkspaceDocument+Tabs.swift
+++ b/AuroraEditor/Base/Documents/Model/WorkspaceDocument/WorkspaceDocument+Tabs.swift
@@ -94,7 +94,7 @@ extension WorkspaceDocument {
                         parameters: [
                             "workspace": self.fileURL?.relativeString ?? "Unknown",
                             "file": item.url.relativeString,
-                            "contents": fileData ?? Data()
+                            "contents": String(data: fileData ?? Data(), encoding: .utf8) ?? ""
                         ]
                     )
                 }

--- a/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
+++ b/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
@@ -133,6 +133,7 @@ public final class ExtensionsManager {
             path: self.extensionsFolder.relativePath + "/" + directory + "/extension.js",
             workspace: workspace
         ) {
+            Log.info("Registered extension \(extensionName)")
             loadedExtensions[directory] = extensionInterface
         } else {
             Log.fault("Failed to load \(extensionName)")

--- a/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
+++ b/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
@@ -92,8 +92,9 @@ public final class ExtensionsManager {
             )
 
             for file in directory {
-                Log.info("Extension path: \(file + "/extension.js")")
-                if FileManager.default.fileExists(atPath: file + "/extension.js") {
+                if file.hasSuffix("JSext") {
+                    // TODO: Remove log.
+                    Log.info("\(file) is a JS extension, we should load it.")
                     loadJSExtension(at: file)
                 }
 
@@ -126,9 +127,22 @@ public final class ExtensionsManager {
         }
     }
 
-    private func loadJSExtension(at path: String) {
-        if let extensionInterface = JSSupport(name: "test-extension", workspace: workspace) {
-            loadedExtensions[path] = extensionInterface
+    private func loadJSExtension(at directory: String) {
+        Log.info("Loading JS Extension \(directory) now")
+        let extensionName = directory.replacingOccurrences(of: ".JSext", with: "")
+
+        if let extensionInterface = JSSupport(
+            name: extensionName,
+            path: self.extensionsFolder.relativePath + "/" + directory + "/extension.js",
+            workspace: workspace
+        ) {
+            loadedExtensions[directory] = extensionInterface
+        } else {
+            Log.fault("Failed to load \(extensionName)")
+            auroraMessageBox(
+                type: .critical,
+                message: "Failed to load \(extensionName)"
+            )
         }
     }
 

--- a/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
+++ b/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
@@ -48,14 +48,13 @@ public final class ExtensionsManager {
             "Extensions",
             isDirectory: true
         )
-
-        loadPlugins()
     }
 
     /// Set workspace document
     /// - Parameter workspace: Workspace document
     func set(workspace: WorkspaceDocument) {
         self.workspace = workspace
+        loadPlugins()
     }
 
     /// Create an Aurora API Callback handler.
@@ -92,31 +91,44 @@ public final class ExtensionsManager {
                 atPath: extensionsFolder.relativePath
             )
 
-            for file in directory where file.hasSuffix("AEext") {
-                if let builder = self.loadBundle(path: file) {
-                    loadedExtensions[file] = builder.init().build(
-                        withAPI: AuroraEditorAPI(extensionId: "0", workspace: workspace ?? .init())
-                    )
+            for file in directory {
+                Log.info("Extension path: \(file + "/extension.js")")
+                if FileManager.default.fileExists(atPath: file + "/extension.js") {
+                    loadJSExtension(at: file)
+                }
 
-                    loadedExtensions[file]?.respond(
-                        action: "registerCallback",
-                        parameters: ["callback": auroraAPICallback(file: file)]
-                    )
+                if file.hasSuffix("AEext") {
+                    if let builder = self.loadBundle(path: file) {
+                        loadedExtensions[file] = builder.init().build(
+                            withAPI: AuroraEditorAPI(extensionId: "0", workspace: workspace ?? .init())
+                        )
 
-                    Log.info("Registered \(file)")
-                } else {
-                    Log.warning("Failed to init() \(file)")
-                    Log.fault("\(file) is compiled for a different version of AuroraEditor.")
-                    auroraMessageBox(
-                        type: .critical,
-                        message: "\(file) is compiled for a different version of AuroraEditor.\n" +
-                                "Please unload this plugin, or update it"
-                    )
+                        loadedExtensions[file]?.respond(
+                            action: "registerCallback",
+                            parameters: ["callback": auroraAPICallback(file: file)]
+                        )
+
+                        Log.info("Registered \(file)")
+                    } else {
+                        Log.warning("Failed to init() \(file)")
+                        Log.fault("\(file) is compiled for a different version of AuroraEditor.")
+                        auroraMessageBox(
+                            type: .critical,
+                            message: "\(file) is compiled for a different version of AuroraEditor.\n" +
+                            "Please unload this plugin, or update it"
+                        )
+                    }
                 }
             }
         } catch {
             Log.fault("Error while loading plugins \(error.localizedDescription)")
             return
+        }
+    }
+
+    private func loadJSExtension(at path: String) {
+        if let extensionInterface = JSSupport(name: "test-extension", workspace: workspace) {
+            loadedExtensions[path] = extensionInterface
         }
     }
 

--- a/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
+++ b/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
@@ -93,8 +93,6 @@ public final class ExtensionsManager {
 
             for file in directory {
                 if file.hasSuffix("JSext") {
-                    // TODO: Remove log.
-                    Log.info("\(file) is a JS extension, we should load it.")
                     loadJSExtension(at: file)
                 }
 

--- a/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
+++ b/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
@@ -126,7 +126,6 @@ public final class ExtensionsManager {
     }
 
     private func loadJSExtension(at directory: String) {
-        Log.info("Loading JS Extension \(directory) now")
         let extensionName = directory.replacingOccurrences(of: ".JSext", with: "")
 
         if let extensionInterface = JSSupport(

--- a/AuroraEditor/Base/Extensions/Models/JSSupport.swift
+++ b/AuroraEditor/Base/Extensions/Models/JSSupport.swift
@@ -54,8 +54,8 @@ class JSSupport: ExtensionInterface {
         // Register JS Functions
         registerJS()
 
-        // Load the JS Extension
-        if !loadJSExtension(path: path) {
+        // Load the JS Extension, do NEVER return nil if we are running tests.
+        if !loadJSExtension(path: path) && name != "AEXCTestCase" {
             return nil
         }
     }

--- a/AuroraEditor/Base/Extensions/Models/JSSupport.swift
+++ b/AuroraEditor/Base/Extensions/Models/JSSupport.swift
@@ -151,6 +151,8 @@ class JSSupport: ExtensionInterface {
     ///   - parameters: with parameters
     /// - Returns: response value from javascript
     func respond(action: String, parameters: [String: Any]) -> JSValue? {
+        jsLogger.debug("\(action)(\(Array(parameters.values)))")
+
         return context
             .objectForKeyedSubscript(action)?
             .call(withArguments: Array(parameters.values))

--- a/AuroraEditor/Base/Extensions/Models/JSSupport.swift
+++ b/AuroraEditor/Base/Extensions/Models/JSSupport.swift
@@ -66,7 +66,7 @@ class JSSupport: ExtensionInterface {
         do {
             let content = try String(contentsOfFile: path)
 
-            if let value = context.evaluateScript(content),
+            if let value = context.evaluateScript(content + aeContextDidLoad),
                // If the value is not AEContext, it has failed to load
                // See `aeContextDidLoad` fore more information.
                value.toString() != "AEContext" {

--- a/AuroraEditor/Base/Extensions/Models/JSSupport.swift
+++ b/AuroraEditor/Base/Extensions/Models/JSSupport.swift
@@ -45,9 +45,10 @@ class JSSupport: ExtensionInterface {
 
     /// Initialize
     /// - Parameter workspace: workspace document
-    init?(name: String, workspace: WorkspaceDocument?) {
+    init?(name: String, path: String, workspace: WorkspaceDocument?) {
         // Set the extension name
-        extensionName = name
+        self.extensionName = name
+        self.workspace = workspace
 
         // Rewrite jsLogger to use the extension name as category.
         jsLogger = Logger(
@@ -59,28 +60,31 @@ class JSSupport: ExtensionInterface {
         registerJS()
 
         // Load the JS Extension
-        loadJSExtension()
+        if !loadJSExtension(path: path) {
+            return nil
+        }
     }
 
     /// Register JS Extension
     /// - Parameter script: extension path
-    public func loadJSExtension() {
-        if let path = Bundle.main.path(forResource: extensionName, ofType: "js") {
-            do {
-                let content = try String(contentsOfFile: path)
+    public func loadJSExtension(path: String) -> Bool {
+        do {
+            let content = try String(contentsOfFile: path)
 
-                if let value = context.evaluateScript(content),
-                    value.toString() != "AEContext" {
-                    jsLogger.error("Extension \"\(self.extensionName)\" failed to load.")
-                }
-            } catch {
-                jsLogger.error(
-                    "Could not read the contents of \"\(self.extensionName)\" (extension.js), Error: \(error)"
-                )
+            if let value = context.evaluateScript(content),
+               value.toString() != "AEContext" {
+                jsLogger.error("Extension \"\(self.extensionName)\" failed to load.")
+                return false
             }
-        } else {
-            jsLogger.error("Error extension \"\(self.extensionName)\" not found.")
+        } catch {
+            jsLogger.error(
+                "Could not read the contents of \"\(self.extensionName)\" (extension.js), Error: \(error)"
+            )
+
+            return false
         }
+
+        return true
     }
 
     func registerJS() {

--- a/AuroraEditor/Base/Extensions/Models/JSSupport.swift
+++ b/AuroraEditor/Base/Extensions/Models/JSSupport.swift
@@ -13,16 +13,9 @@ import AEExtensionKit
 
 /// This class is used to support JavaScript extensions in AuroraEditor.
 /// This class has no static function since we need to run a new instance for every extension.
-/// Usage:
-///
-///     let jssupport = JSSupport(WorkspaceDocument)` // to create a new instance.
-///     jssuport.register("MyExtension") // to register the extension.
 class JSSupport: ExtensionInterface {
     /// Create the os_log logger
-    var jsLogger = Logger(
-        subsystem: "com.auroraeditor.JSSupport",
-        category: "JSSupport"
-    )
+    var jsLogger: Logger
 
     /// The current JavaScript context where we are running in
     var context = JSContext()!
@@ -48,9 +41,11 @@ class JSSupport: ExtensionInterface {
     init?(name: String, path: String, workspace: WorkspaceDocument?) {
         // Set the extension name
         self.extensionName = name
+
+        // Set the workspace name
         self.workspace = workspace
 
-        // Rewrite jsLogger to use the extension name as category.
+        // Initialize jsLogger to use the extension name as category.
         jsLogger = Logger(
             subsystem: "com.auroraeditor.JSSupport",
             category: name
@@ -72,6 +67,8 @@ class JSSupport: ExtensionInterface {
             let content = try String(contentsOfFile: path)
 
             if let value = context.evaluateScript(content),
+               // If the value is not AEContext, it has failed to load
+               // See `aeContextDidLoad` fore more information.
                value.toString() != "AEContext" {
                 jsLogger.error("Extension \"\(self.extensionName)\" failed to load.")
                 return false

--- a/AuroraEditor/Base/Extensions/Models/JSSupport.swift
+++ b/AuroraEditor/Base/Extensions/Models/JSSupport.swift
@@ -1,0 +1,195 @@
+//
+//  JSSupport.swift
+//  Aurora Editor
+//
+//  Created by Wesley de Groot on 09/04/2024.
+//  Copyright © 2024 Aurora Company. All rights reserved.
+//
+
+import Foundation
+import JavaScriptCore
+import OSLog
+import AEExtensionKit
+
+/// This class is used to support JavaScript extensions in AuroraEditor.
+/// This class has no static function since we need to run a new instance for every extension.
+/// Usage:
+///
+///     let jssupport = JSSupport(WorkspaceDocument)` // to create a new instance.
+///     jssuport.register("MyExtension") // to register the extension.
+class JSSupport: ExtensionInterface {
+    /// Create the os_log logger
+    var jsLogger = Logger(
+        subsystem: "com.auroraeditor.JSSupport",
+        category: "JSSupport"
+    )
+
+    /// The current JavaScript context where we are running in
+    var context = JSContext()!
+
+    /// Responder (typealias because of cleaner code)
+    typealias Responder = @convention (block) (String, [String: Any]) -> Any
+
+    /// Create a function which returns "AEContext", it should be start witht the semicolon because we
+    /// do not know if the last line of the extension is a newline.
+    /// if the result of the total evaluation is "AEContext", the extension did load correctly,
+    /// if the result is any other than that then either the extension developer has a early return,
+    /// or a syntax error.
+    let aeContextDidLoad = ";(function(){return \"AEContext\"})();"
+
+    /// Extension name.
+    var extensionName = ""
+
+    /// Save the current Workspace Document
+    var workspace: WorkspaceDocument?
+
+    /// Initialize
+    /// - Parameter workspace: workspace document
+    init?(name: String, workspace: WorkspaceDocument?) {
+        // Set the extension name
+        extensionName = name
+
+        // Rewrite jsLogger to use the extension name as category.
+        jsLogger = Logger(
+            subsystem: "com.auroraeditor.JSSupport",
+            category: name
+        )
+
+        // Register JS Functions
+        registerJS()
+
+        // Load the JS Extension
+        loadJSExtension()
+    }
+
+    /// Register JS Extension
+    /// - Parameter script: extension path
+    public func loadJSExtension() {
+        if let path = Bundle.main.path(forResource: extensionName, ofType: "js") {
+            do {
+                let content = try String(contentsOfFile: path)
+
+                if let value = context.evaluateScript(content),
+                    value.toString() != "AEContext" {
+                    jsLogger.error("Extension \"\(self.extensionName)\" failed to load.")
+                }
+            } catch {
+                jsLogger.error(
+                    "Could not read the contents of \"\(self.extensionName)\" (extension.js), Error: \(error)"
+                )
+            }
+        } else {
+            jsLogger.error("Error extension \"\(self.extensionName)\" not found.")
+        }
+    }
+
+    func registerJS() {
+        registerErrorHandler()
+        registerScripts()
+        registerFunctions()
+    }
+
+    /// Register the exception handler for JS.
+    /// We should show this for extension developers, so they can use
+    /// `Console.app` to view JS Errors, use `com.auroraeditor.JSSupport` as subsystem
+    /// and the category is your extension name.
+    func registerErrorHandler() {
+        context.exceptionHandler = { _, exception in
+            self.jsLogger.error("JS Error: \(exception?.description ?? "Unknown error")")
+        }
+    }
+
+    func registerFunctions() {
+        let api: @convention (block) (String) -> Bool = { (message: String) in
+            self.jsLogger.debug("JSAPI Message: \(message)")
+
+            return true
+        }
+
+        let respond: Responder = { (action: String, parameters: [String: Any])  in
+            self.jsLogger.debug("JSAPI:\n Function: \(action)\n Parameters: \(String(describing: parameters))")
+
+            // Broadcast the action to Aurora Editor
+            self.workspace?.broadcaster.broadcast(
+                sender: self.extensionName,
+                command: action,
+                parameters: parameters
+            )
+
+            return true
+        }
+
+        /// Create AuroraEditor.api(...)
+        context
+            .objectForKeyedSubscript("AuroraEditor")
+            .setObject(
+                unsafeBitCast(api, to: AnyObject.self),
+                forKeyedSubscript: "api" as (NSCopying & NSObjectProtocol)
+            )
+
+        /// Create AuroraEditor.respond(...)
+        context
+            .objectForKeyedSubscript("AuroraEditor")
+            .setObject(
+                unsafeBitCast(respond, to: AnyObject.self),
+                forKeyedSubscript: "respond" as (NSCopying & NSObjectProtocol)
+            )
+    }
+
+    /// Register the required AuroraEditor class.
+    func registerScripts() {
+        // Make sure AuroraEditor is defined.
+        // This script will be filled with aliases and more.
+        context
+            .evaluateScript("var AuroraEditor = {};")
+    }
+
+    /// Respond to an (AuroraEditor) JavaScript function.
+    /// - Parameters:
+    ///   - action: action to perform
+    ///   - parameters: with parameters
+    /// - Returns: response value from javascript
+    func respond(action: String, parameters: [String: Any]) -> JSValue? {
+        return context
+            .objectForKeyedSubscript(action)?
+            .call(withArguments: Array(parameters.values))
+    }
+
+    /// Respond to an (AuroraEditor) JavaScript function.
+    /// - Parameters:
+    ///   - action: action to perform
+    ///   - parameters: with parameters
+    /// - Returns: response value from javascript
+    func respondToAE(action: String, parameters: [String: Any]) -> JSValue? {
+        return context
+            .objectForKeyedSubscript("AuroraEditor")?
+            .objectForKeyedSubscript(action)?
+            .call(withArguments: Array(parameters.values))
+    }
+
+    /// Evaluate a script on the current context
+    /// - Parameter script: script to evaluate
+    /// - Returns: the JS Value
+    func evaluate(script: String) -> JSValue? {
+        return context
+            .evaluateScript(script)
+    }
+
+    // MARK: - Aurora Editor Extension interface
+    func respond(action: String, parameters: [String: Any]) -> Bool {
+        if let val = self.respond(action: action, parameters: parameters), val.isBoolean {
+            return val.toBool()
+        }
+
+        return true
+    }
+
+    func register() -> AEExtensionKit.ExtensionManifest {
+        return .init(
+            name: extensionName,
+            displayName: extensionName,
+            version: "1.0.0",
+            minAEVersion: "0.0.1"
+        )
+    }
+}

--- a/AuroraEditor/Base/Extensions/Models/JSSupport.swift
+++ b/AuroraEditor/Base/Extensions/Models/JSSupport.swift
@@ -151,8 +151,6 @@ class JSSupport: ExtensionInterface {
     ///   - parameters: with parameters
     /// - Returns: response value from javascript
     func respond(action: String, parameters: [String: Any]) -> JSValue? {
-        jsLogger.debug("\(action)(\(Array(parameters.values)))")
-
         return context
             .objectForKeyedSubscript(action)?
             .call(withArguments: Array(parameters.values))


### PR DESCRIPTION
## Summary

This (small) PR enables JavaScript extension support.

## Changes Made

- Added JavaScript extension support
- Changed the way that Extensions initialise, to be sure that WorkspaceDocument is always set before we load extensions, this _prevents_ extensions being loaded if there is no workspace document (on the welcome screen), but it improves the fact that extensions always can send commands to Aurora Editor, maybe we should change this at _some_ point, but this change is intentional.
- didOpen will not send Data anymore, since we can't pass Data to JavaScript. it's being converted to String.

## TODO (Out of Scope)

- Add aliases in the `AuroraEditor` JavaScript class.
- Add support for loading multiple `.js` files
- Parse manifest/config file
- (later on) support GUI.

## Motivation

Developers want to create extensions in JavaScript.

## Testing

All current implementations contain tests.
- `testJSAPIUsingEvaluate()`
- `testJSAPIUsingRespondToApi()`
- `testJSAPIUsingRespondToCustomApi()`
- `testJSAPIUsingRespondUsingEvaluate()`
- `testJSAPIWhichShouldFailToExecute()`

## Screenshots/GIFs

<img width="1110" alt="71F009EF-BFFF-432D-8FDD-063A18398DAB" src="https://github.com/AuroraEditor/AuroraEditor/assets/1290461/f82e5daa-eec1-4e1f-b69c-d329ccdc05f0">

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [x] Code has been tested and verified.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully.
- [x] Code follows the project's coding guidelines and style.
- [x] The branch is up-to-date with the latest changes from the main branch.
- [x] Reviewed by at least one other contributor.

## Related Issues

This fixes #364 as well.

## Additional Notes

There is currently no option for JavaScript extensions to present a GUI.
This will come in a later stadium, and is therefore out of scope for this PR.

## Create & Run your own extension:
```bash
# Create ~/Library/Application Support/com.auroraeditor/Extensions/JavaScriptExtension.JSext
mkdir -p "$HOME/Library/Application Support/com.auroraeditor/Extensions/JavaScriptExtension.JSext"
# Create ~/Library/Application Support/com.auroraeditor/Extensions/JavaScriptExtension.JSext/extension.js
echo "AuroraEditor.respond(\"showError\",{\"message\":\"I'm a JavaScript Extension\!\"});" > "$HOME/Library/Application Support/com.auroraeditor/Extensions/JavaScriptExtension.JSext/extension.js"
```

Respond to Editor events: (e.g. https://auroraeditor.github.io/AEExtensionKit-Documentation/#didopen-1 )
```
function didOpen(workspace, file, contents) {
    AuroraEditor.respond("showError", { "message": "Opened " + file });
}
```
<img width="1110" alt="image" src="https://github.com/AuroraEditor/AuroraEditor/assets/1290461/459a8842-bb8a-4cc8-a830-0685d1c6b3db">

Please note the order of parameters are important