### PR TITLE
Rewrite extension event senders

### DIFF
--- a/AuroraEditor/Base/Documents/Model/AuroraEditorWindow/AuroraEditorWindowController+NSToolbarDelegate.swift
+++ b/AuroraEditor/Base/Documents/Model/AuroraEditorWindow/AuroraEditorWindowController+NSToolbarDelegate.swift
@@ -208,14 +208,12 @@ extension AuroraEditorWindowController: NSToolbarDelegate {
         guard let navigatorPane = splitViewController.splitViewItems.first else { return }
         navigatorPane.animator().isCollapsed.toggle()
 
-        for (id, AEExt) in ExtensionsManager.shared.loadedExtensions {
-            Log.info("\(id), didToggleNavigatorPane()")
-            AEExt.respond(
-                action: "didToggleNavigatorPane",
-                parameters: [
-                    "opened": !navigatorPane.animator().isCollapsed
-                ])
-        }
+        ExtensionsManager.shared.sendEvent(
+            event: "didToggleNavigatorPane",
+            parameters: [
+                "opened": !navigatorPane.animator().isCollapsed
+            ]
+        )
     }
 
     /// Toggles the visibility of the inspector pane in the application's user interface.
@@ -279,15 +277,12 @@ extension AuroraEditorWindowController: NSToolbarDelegate {
             }
         }
 
-        for (id, AEExt) in ExtensionsManager.shared.loadedExtensions {
-            Log.info("\(id), didToggleInspectorPane()")
-            AEExt.respond(
-                action: "didToggleInspectorPane",
-                parameters: [
-                    "opened": !inspectorPane.animator().isCollapsed
-                ]
-            )
-        }
+        ExtensionsManager.shared.sendEvent(
+            event: "didToggleInspectorPane",
+            parameters: [
+                "opened": !inspectorPane.animator().isCollapsed
+            ]
+        )
     }
 }
 

--- a/AuroraEditor/Base/Documents/Model/AuroraEditorWindow/AuroraEditorWindowController.swift
+++ b/AuroraEditor/Base/Documents/Model/AuroraEditorWindow/AuroraEditorWindowController.swift
@@ -133,14 +133,10 @@ final class AuroraEditorWindowController: NSWindowController, ObservableObject {
             fatalError("Cannot get file")
         }
 
-        for (id, AEExt) in ExtensionsManager.shared.loadedExtensions {
-            Log.info("\(id), didSave()")
-            AEExt.respond(
-                action: "didSave",
-                parameters: [
-                    "file": file.fileURL?.relativeString ?? "Unknown"
-                ])
-        }
+        ExtensionsManager.shared.sendEvent(
+            event: "didSave",
+            parameters: ["file": file.fileURL?.relativeString ?? "Unknown"]
+        )
 
         file.saveFileDocument()
 

--- a/AuroraEditor/Base/Editor/CodeEditorView/UI/CodeEditorView.swift
+++ b/AuroraEditor/Base/Editor/CodeEditorView/UI/CodeEditorView.swift
@@ -81,13 +81,14 @@ extension CodeEditor: NSViewRepresentable {
             updateMessages(in: codeView, with: context)
 
             context.coordinator.caretPosition = .init(line: 0, column: 0)
-            for (id, AEExt) in ExtensionsManager.shared.loadedExtensions {
-                Log.info("\(id), didMoveCaret")
-                AEExt.respond(
-                    action: "didMoveCaret",
-                    parameters: ["row": 0, "col": 0]
-                )
-            }
+
+            ExtensionsManager.shared.sendEvent(
+                event: "didMoveCaret",
+                parameters: [
+                    "row": 0,
+                    "col": 0
+                ]
+            )
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -156,15 +157,13 @@ extension CodeEditor: NSViewRepresentable {
                 col = txtStr.count
             }
 
-            for (id, AEExt) in ExtensionsManager.shared.loadedExtensions {
-                Log.info("\(id), didMoveCaret")
-                AEExt.respond(
-                    action: "didMoveCaret",
-                    parameters: [
-                        "row": row,
-                        "col": col
-                    ])
-            }
+            ExtensionsManager.shared.sendEvent(
+                event: "didMoveCaret",
+                parameters: [
+                    "row": row,
+                    "col": col
+                ]
+            )
 
             return .init(line: row, column: col)
         }

--- a/AuroraEditor/Base/Editor/UI/CodeFile.swift
+++ b/AuroraEditor/Base/Editor/UI/CodeFile.swift
@@ -76,16 +76,13 @@ public final class CodeFileDocument: NSDocument, ObservableObject, QLPreviewItem
             }
         }
 
-        for (id, AEExt) in ExtensionsManager.shared.loadedExtensions {
-            Log.info("\(id), didOpen")
-            AEExt.respond(
-                action: "didOpen",
-                parameters: [
-                    "file": self.fileURL?.relativeString ?? "Unknown",
-                    "contents": self.content.data(using: .utf8) ?? Data()
-                ]
-            )
-        }
+        ExtensionsManager.shared.sendEvent(
+            event: "didOpen",
+            parameters: [
+                "file": self.fileURL?.relativeString ?? "Unknown",
+                "contents": self.content.data(using: .utf8) ?? Data()
+            ]
+        )
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1400, height: 600),

--- a/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
+++ b/AuroraEditor/Base/Extensions/Models/ExtensionsManager.swift
@@ -16,16 +16,16 @@ public final class ExtensionsManager {
     public static let shared: ExtensionsManager = ExtensionsManager()
 
     /// Aurora Editor folder (`~/Library/com.auroraeditor/`)
-    let auroraEditorFolder: URL
+    private let auroraEditorFolder: URL
 
     /// Aurora Editor extensions folder (`~/Library/com.auroraeditor/Extensions`)
-    let extensionsFolder: URL
+    public let extensionsFolder: URL
 
     /// Dictionary of current loaded extensions
-    var loadedExtensions: [String: ExtensionInterface] = [:]
+    private(set) var loadedExtensions: [String: ExtensionInterface] = [:]
 
     /// The current workspace document
-    var workspace: WorkspaceDocument?
+    private var workspace: WorkspaceDocument?
 
     init() {
         Log.info("[ExtensionsManager] init()")
@@ -220,6 +220,25 @@ public final class ExtensionsManager {
         #endif
 
         return task
+    }
+
+    /// Send event to all loaded extensions
+    /// - Parameters:
+    ///   - event: Event to send
+    ///   - parameters: Parameters to send
+    public func sendEvent(event: String, parameters: [String: Any]) {
+        DispatchQueue.main.async {
+            var params = Array(parameters.keys).joined(separator: ": ..., ")
+
+            Log.info(
+                "[Extension] send \(event)(\(params)) to \(ExtensionsManager.shared.loadedExtensions.count) extensions."
+            )
+
+            // Let the extensions know we opened a file (from a workspace)
+            for (id, AEExt) in ExtensionsManager.shared.loadedExtensions {
+                AEExt.respond(action: event, parameters: parameters)
+            }
+        }
     }
 
     /// Is installed

--- a/AuroraEditor/Base/TabBar/UI/TabBarItem/TabBarItem.swift
+++ b/AuroraEditor/Base/TabBar/UI/TabBarItem/TabBarItem.swift
@@ -104,27 +104,19 @@ struct TabBarItem: View {
         }
         .onAppear {
             isTemporary = workspace.selectionState.temporaryTab == item.tabID
-            for (id, AEExt) in ExtensionsManager.shared.loadedExtensions {
-                Log.info("\(id), didActivateTab")
-                AEExt.respond(
-                    action: "didActivateTab",
-                    parameters: [
-                        "file": item.tabID.fileRepresentation
-                    ])
-            }
+            ExtensionsManager.shared.sendEvent(
+                event: "didActivateTab",
+                parameters: ["file": item.tabID.fileRepresentation]
+            )
         }
         .onChange(of: workspace.selectionState.temporaryTab) { _ in
             isTemporary = workspace.selectionState.temporaryTab == item.tabID
         }
         .onChange(of: isActive, perform: { newValue in
-            for (id, AEExt) in ExtensionsManager.shared.loadedExtensions {
-                Log.info("\(id), \(newValue ? "didActivateTab" : "didDeactivateTab")")
-                AEExt.respond(
-                    action: newValue ? "didActivateTab" : "didDeactivateTab",
-                    parameters: [
-                        "file": item.tabID.fileRepresentation
-                    ])
-            }
+            ExtensionsManager.shared.sendEvent(
+                event: newValue ? "didActivateTab" : "didDeactivateTab",
+                parameters: ["file": item.tabID.fileRepresentation]
+            )
         })
         .overlay(alignment: .top) {
             // Only show NativeTabShadow when `tabBarStyle` is native and this tab is not active.


### PR DESCRIPTION
## Summary

Rewrite extension event senders

## Changes Made

Rewrite extension event senders, this makes it easier to send Events.

```swift
ExtensionsManager.shared.sendEvent(
     event: "eventName",
     parameters: [
         "parameter": "value"
     ]
)
```

## TODO

None

## Motivation

Make it easier to send events

## Testing

N/A

## Screenshots/GIFs

N/A

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [x] Code has been tested and verified.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully.
- [x] Code follows the project's coding guidelines and style.
- [x] The branch is up-to-date with the latest changes from the main branch.
- [x] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): None

## Additional Notes

None