### PR TITLE
Added Deprecation Notices for Version Control System Remote Calls

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,7 +13,6 @@ excluded:
   - AuroraEditorModules/.build # Where Swift Package Manager checks out dependency sources
   - AuroraEditorCli/Package.swift # Package.swift should not be linted
   - Tools # Tools should not be linted
-  - AEquicklook # Check if we can move the js/css into a separate file and load via bundle. @0xWDG
   - "AuroraEditor/Base/Version Control" # This will be removed soon, @nanashili remove when done.
 
 # Exclude triggering type names.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,6 +14,7 @@ excluded:
   - AuroraEditorCli/Package.swift # Package.swift should not be linted
   - Tools # Tools should not be linted
   - AEquicklook # Check if we can move the js/css into a separate file and load via bundle. @0xWDG
+  - "AuroraEditor/Base/Version Control" # This will be removed soon, @nanashili remove when done.
 
 # Exclude triggering type names.
 type_name:

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/BitbucketAccount+Token.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/BitbucketAccount+Token.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Bitbucket account
 public extension BitbucketAccount {
     /// Refresh token

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/BitbucketAccount.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/BitbucketAccount.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// BitBucket base URL
 public let bitbucketBaseURL = "https://api.bitbucket.org/2.0"
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/BitbucketOAuthConfiguration.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/BitbucketOAuthConfiguration.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Bitbucket OAuth configuration
 public struct BitbucketOAuthConfiguration: GitConfiguration {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/BitbucketTokenConfiguration.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/BitbucketTokenConfiguration.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Bitbucket token configuration
 public struct BitbucketTokenConfiguration: GitConfiguration {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Model/BitbucketRepositories.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Model/BitbucketRepositories.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// BitbucketRepositories
 open class BitbucketRepositories: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Model/BitbucketUser.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Model/BitbucketUser.swift
@@ -9,6 +9,7 @@
 import Foundation
 import SwiftUI
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Bitbucket user
 open class BitbucketUser: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Routers/BitbucketRepositoryRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Routers/BitbucketRepositoryRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Bitbucket repository router
 public enum BitbucketRepositoryRouter: Router {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Routers/BitbucketUserRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Routers/BitbucketUserRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Bitbucket user router
 public enum BitbucketUserRouter: Router {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Routers/OAuthRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Routers/OAuthRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// OAuth router
 public enum OAuthRouter: Router {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Routers/TokenRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Bitbucket/Routers/TokenRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Token router
 public enum TokenRouter: Router {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/GithubAccount.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/GithubAccount.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// GitHub Base URL
 public let githubBaseURL = "https://api.github.com"
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/GithubConfiguration.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/GithubConfiguration.swift
@@ -11,6 +11,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Github token configuration
 public struct GithubTokenConfiguration: GitConfiguration {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Comment.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Comment.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Github comment
 public struct Comment: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Files.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Files.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Files (`[String:File]`)
 public typealias Files = [String: File]
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Gist.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Gist.swift
@@ -11,6 +11,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Gist class
 open class Gist: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Git.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Git.swift
@@ -11,6 +11,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 public extension GithubAccount {
 
     /// Deletes a reference.

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/GithubRepositories.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/GithubRepositories.swift
@@ -11,6 +11,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Github Repositories
 open class GithubRepositories: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/GithubUser.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/GithubUser.swift
@@ -11,6 +11,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Github User
 open class GithubUser: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Issue.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Issue.swift
@@ -11,6 +11,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Github Issue
 open class Issue: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/PullRequest.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/PullRequest.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Pull Request
 open class PullRequest: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Review.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Model/Review.swift
@@ -11,6 +11,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Review
 public struct Review {
     /// Body

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Openness.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Openness.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Github issue/pull request state
 public enum Openness: String, Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/PreviewHeader.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/PreviewHeader.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Some APIs provide additional data for new (preview) APIs if a custom header is added to the request.
 ///
 /// - Note: Preview APIs are subject to change.

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/PublicKey.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/PublicKey.swift
@@ -11,6 +11,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 public extension GithubAccount {
     /// Post Public key
     /// 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/GistRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/GistRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Gist Router
 enum GistRouter: JSONPostRouter {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/GitRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/GitRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Git Router
 enum GitRouter: JSONPostRouter {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/GithubRepositoryRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/GithubRepositoryRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Github Repository Router
 enum GithubRepositoryRouter: Router {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/GithubUserRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/GithubUserRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Github User Router
 enum GithubUserRouter: Router {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/IssueRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/IssueRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Issue Router
 enum IssueRouter: JSONPostRouter {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/PullRequestRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/PullRequestRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Pull Request Router
 enum PullRequestRouter: JSONPostRouter {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/ReviewsRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Github/Routers/ReviewsRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Reviews Router
 enum ReviewsRouter: JSONPostRouter {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/GitlabAccount.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/GitlabAccount.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Gitlab Base URL
 public let gitlabBaseURL = "https://gitlab.com/api/v4/"
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/GitlabConfiguration.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/GitlabConfiguration.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Gitlab token configuration
 public struct GitlabTokenConfiguration: GitConfiguration {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/GitlabOAuthConfiguration.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/GitlabOAuthConfiguration.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Gitlab OAuth Configuration
 public struct GitlabOAuthConfiguration: GitConfiguration {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/AvatarURL.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/AvatarURL.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Avatar URL
 open class AvatarURL: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/Event.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/Event.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Event Data
 open class Event: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/EventData.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/EventData.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Event Data
 open class EventData: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/EventNote.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/EventNote.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Event Note
 open class EventNote: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/GitlabAccountModel.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/GitlabAccountModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 public extension GitlabAccount {
     /// Fetches the Projects for which the authenticated user is a member.
     /// 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/GitlabCommit.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/GitlabCommit.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Gitlab Commit
 open class GitlabCommit: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/GitlabUser.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/GitlabUser.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Gitlab User
 open class GitlabUser: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/GroupAccess.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/GroupAccess.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Group Access
 open class GroupAccess: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/Namespace.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/Namespace.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Git Name Space
 open class GitNameSpace: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/Permissions.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/Permissions.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Permissions
 open class Permissions: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/Project.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/Project.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Visibility Level
 public enum VisibilityLevel: Int {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/ProjectAccess.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/ProjectAccess.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Project Access
 open class ProjectAccess: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/ProjectHook.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Model/ProjectHook.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Project Hook
 open class ProjectHook: Codable {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Routers/CommitRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Routers/CommitRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Commit Router
 enum CommitRouter: Router {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Routers/GitlabOAuthRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Routers/GitlabOAuthRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Gitlab OAuth Router
 enum GitlabOAuthRouter: Router {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Routers/ProjectRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Routers/ProjectRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Visibility
 public enum Visibility: String {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Routers/UserRouter.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Gitlab/Routers/UserRouter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// User Router
 enum UserRouter: Router {
 

--- a/AuroraEditor/Base/Version Control/Model/Accounts/Parameters.swift
+++ b/AuroraEditor/Base/Version Control/Model/Accounts/Parameters.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Sort direction
 public enum SortDirection: String {
 

--- a/AuroraEditor/Base/Version Control/Model/Actions/GitHubActionsModel.swift
+++ b/AuroraEditor/Base/Version Control/Model/Actions/GitHubActionsModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Version_Control
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Github actions model
 class GitHubActions: ObservableObject {
 

--- a/AuroraEditor/Base/Version Control/Model/Client/Core/GitClient.swift
+++ b/AuroraEditor/Base/Version Control/Model/Client/Core/GitClient.swift
@@ -13,6 +13,7 @@ import Combine
 import Version_Control
 import OSLog
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 // A protocol to make calls to terminal to init a git call.
 public class GitClient: ObservableObject { // swiftlint:disable:this type_body_length
 

--- a/AuroraEditor/Base/Version Control/Model/Client/Core/GitClientError.swift
+++ b/AuroraEditor/Base/Version Control/Model/Client/Core/GitClientError.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Git Client
 extension GitClient {
 

--- a/AuroraEditor/Base/Version Control/Model/GitUIModel.swift
+++ b/AuroraEditor/Base/Version Control/Model/GitUIModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// A Git UI Model
 public final class GitUIModel: ObservableObject {
     /// A GitClient instance

--- a/AuroraEditor/Base/Version Control/Model/Project History/BranchCommitHistory.swift
+++ b/AuroraEditor/Base/Version Control/Model/Project History/BranchCommitHistory.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import Version_Control
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Branch Commit History
 final class BranchCommitHistory: Equatable, Identifiable, TabBarItemRepresentable, ObservableObject {
 

--- a/AuroraEditor/Base/Version Control/Model/Project History/ProjectCommitHistory.swift
+++ b/AuroraEditor/Base/Version Control/Model/Project History/ProjectCommitHistory.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import Version_Control
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// Project Commit History
 final class ProjectCommitHistory: Equatable, Identifiable, TabBarItemRepresentable, ObservableObject {
 

--- a/AuroraEditor/Base/Version Control/Networking/JSONPostRouter.swift
+++ b/AuroraEditor/Base/Version Control/Networking/JSONPostRouter.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 // TODO: Rebuild Networking Layer for Accounts
 public protocol JSONPostRouter: Router {
     /// Post JSON

--- a/AuroraEditor/Base/Version Control/Networking/Router.swift
+++ b/AuroraEditor/Base/Version Control/Networking/Router.swift
@@ -11,6 +11,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// HTTP Encoding
 public enum HTTPEncoding: Int {
     case url, form, json

--- a/AuroraEditor/Base/Version Control/Networking/Session.swift
+++ b/AuroraEditor/Base/Version Control/Networking/Session.swift
@@ -11,6 +11,7 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "VersionControl", message: "This will be deprecated in favor of the new VersionControl Remote SDK APIs.")
 /// GIT URLSession
 public protocol GitURLSession {
 


### PR DESCRIPTION
This pull request introduces deprecation notices to the current remote calls within the version control system of the editor. The changes are necessary as we transition to using the standalone [Version Control Kit](https://github.com/AuroraEditor/Version-Control-Kit). The existing remote call system is outdated and lacks the performance optimizations required for modern usage, warranting a complete rewrite.

## Details:

* Deprecation Notices:
   * Added deprecation annotations to all functions and classes involved in remote calls within the current version control system.
   * Provided clear messages indicating the move to the new Version Control Kit and the upcoming changes.
   
* Transition Plan:
  * All remote calls will be moved to the new Version Control Kit repository.
  * The current system for remote calls will remain in place temporarily to ensure the editor remains fully functional during the transition period.

* Rationale:
  * The existing system is not performant and does not meet the current standards for remote operations.
  * The new Version Control Kit offers a more robust and efficient framework for handling version control operations.
  * The transition to the new kit will improve overall performance, maintainability, and future scalability of the editor.

* Next Steps:
  - Complete the rewrite of the remote call system within the Version Control Kit.
  - Gradually phase out the deprecated calls from the editor once the new system is fully integrated and tested.
  - Provide documentation and support to assist developers in adapting to the new system.

## Impact:

1. Users and developers will see deprecation warnings indicating the upcoming changes.
2. Existing functionality will remain unaffected until the new system is fully operational.
3. A smoother transition is ensured, minimizing disruptions to the editor’s use.