### PR TITLE
Fix: View `.log{}` extension did not execute closure

### DIFF
--- a/AuroraEditor/Utils/Log.swift
+++ b/AuroraEditor/Utils/Log.swift
@@ -34,6 +34,7 @@ extension View {
     /// - Parameter closure: Code need to run
     /// - Returns: self
     func log(_ closure: () -> Void) -> some View {
+        _ = closure()
         return self
     }
 }


### PR DESCRIPTION
## Summary

View `.log{}` extension did not execute closure

## Changes Made

Made the extension execute the closure

## TODO

None

## Motivation

For logging

## Testing

None

## Screenshots/GIFs

None

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [x] Code has been tested and verified.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully.
- [x] Code follows the project's coding guidelines and style.
- [x] The branch is up-to-date with the latest changes from the main branch.
- [x] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): None

## Additional Notes

None