### PR TITLE
Fix: Extensions: Redone JavaScript Extension Calling

### DIFF
--- a/Aurora Editor.xcodeproj/project.pbxproj
+++ b/Aurora Editor.xcodeproj/project.pbxproj
@@ -405,9 +405,10 @@
 		2B615AB72BC85A4300A5457F /* ExtensionCustomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B615AB62BC85A4300A5457F /* ExtensionCustomViewModel.swift */; };
 		2B615ABA2BC865B500A5457F /* ExtensionOrWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B615AB92BC865B500A5457F /* ExtensionOrWebView.swift */; };
 		2B615ABC2BC865E400A5457F /* ExtensionViewStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B615ABB2BC865E400A5457F /* ExtensionViewStorage.swift */; };
+		2B6B3D6D2C3820A100B041B5 /* ExtensionDocumentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = 2B6B3D6C2C3820A000B041B5 /* ExtensionDocumentation.docc */; };
 		2B6CB09E2AFFA3B1001E4955 /* AEUpdateService.app in Resources */ = {isa = PBXBuildFile; fileRef = A01AB2D12ACC9EDA0029EDF0 /* AEUpdateService.app */; };
-		2B74A3F02C0F8FFA002498F5 /* JSPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B74A3EF2C0F8FFA002498F5 /* JSPromise.swift */; };
-		2B74A3F22C0F90B2002498F5 /* JSFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B74A3F12C0F90B2002498F5 /* JSFetch.swift */; };
+		2B74A3F02C0F8FFA002498F5 /* JSCPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B74A3EF2C0F8FFA002498F5 /* JSCPromise.swift */; };
+		2B74A3F22C0F90B2002498F5 /* JSCFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B74A3F12C0F90B2002498F5 /* JSCFetch.swift */; };
 		2B7A56B62BD5037C00A728D7 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 2B7A56B52BD5036900A728D7 /* Localizable.xcstrings */; };
 		2B7A583527E4BA0100D25D4E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* AppDelegate.swift */; };
 		2B7AC06B282452FB0082A5B8 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B7AC06A282452FB0082A5B8 /* Media.xcassets */; };
@@ -421,7 +422,7 @@
 		2BCBAACA2927C65500D4DFB2 /* View+isHidden.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCBAAC92927C65500D4DFB2 /* View+isHidden.swift */; };
 		2BCDF9D8295F2EBB00570253 /* .githash in Copy .githash */ = {isa = PBXBuildFile; fileRef = 2BCDF9D6295F2E9700570253 /* .githash */; };
 		2BD0BD142977331400629A86 /* VibrantEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD0BD132977331400629A86 /* VibrantEffect.swift */; };
-		2BDE0F772BC8874900C20B85 /* JSTimerSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDE0F762BC8874800C20B85 /* JSTimerSupport.swift */; };
+		2BDE0F772BC8874900C20B85 /* JSCTimerSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDE0F762BC8874800C20B85 /* JSCTimerSupport.swift */; };
 		2BDFA8F928D1079700980385 /* WebTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDFA8F728D1079600980385 /* WebTab.swift */; };
 		2BDFA90428D107B200980385 /* WebWKView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDFA8FB28D107B200980385 /* WebWKView.swift */; };
 		2BDFA90528D107B200980385 /* OtherFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDFA8FC28D107B200980385 /* OtherFileView.swift */; };
@@ -1015,9 +1016,10 @@
 		2B615AB62BC85A4300A5457F /* ExtensionCustomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCustomViewModel.swift; sourceTree = "<group>"; };
 		2B615AB92BC865B500A5457F /* ExtensionOrWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionOrWebView.swift; sourceTree = "<group>"; };
 		2B615ABB2BC865E400A5457F /* ExtensionViewStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionViewStorage.swift; sourceTree = "<group>"; };
+		2B6B3D6C2C3820A000B041B5 /* ExtensionDocumentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = ExtensionDocumentation.docc; sourceTree = "<group>"; };
 		2B71C0A32874AD61008E0859 /* AuroraProject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuroraProject.swift; sourceTree = "<group>"; };
-		2B74A3EF2C0F8FFA002498F5 /* JSPromise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSPromise.swift; sourceTree = "<group>"; };
-		2B74A3F12C0F90B2002498F5 /* JSFetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSFetch.swift; sourceTree = "<group>"; };
+		2B74A3EF2C0F8FFA002498F5 /* JSCPromise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSCPromise.swift; sourceTree = "<group>"; };
+		2B74A3F12C0F90B2002498F5 /* JSCFetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSCFetch.swift; sourceTree = "<group>"; };
 		2B7A56B52BD5036900A728D7 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		2B7AC06A282452FB0082A5B8 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		2B7C8CC52BC5B3160061DE0D /* JSSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSSupport.swift; sourceTree = "<group>"; };
@@ -1028,7 +1030,7 @@
 		2BCBAAC92927C65500D4DFB2 /* View+isHidden.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+isHidden.swift"; sourceTree = "<group>"; };
 		2BCDF9D6295F2E9700570253 /* .githash */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .githash; sourceTree = "<group>"; };
 		2BD0BD132977331400629A86 /* VibrantEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrantEffect.swift; sourceTree = "<group>"; };
-		2BDE0F762BC8874800C20B85 /* JSTimerSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSTimerSupport.swift; sourceTree = "<group>"; };
+		2BDE0F762BC8874800C20B85 /* JSCTimerSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSCTimerSupport.swift; sourceTree = "<group>"; };
 		2BDFA8F728D1079600980385 /* WebTab.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebTab.swift; sourceTree = "<group>"; };
 		2BDFA8FB28D107B200980385 /* WebWKView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebWKView.swift; sourceTree = "<group>"; };
 		2BDFA8FC28D107B200980385 /* OtherFileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OtherFileView.swift; sourceTree = "<group>"; };
@@ -1856,6 +1858,7 @@
 		20D837BC289A7ACD00D91D05 /* ExtensionSystem */ = {
 			isa = PBXGroup;
 			children = (
+				2B6B3D6C2C3820A000B041B5 /* ExtensionDocumentation.docc */,
 				20D837BF289A7ACD00D91D05 /* Models */,
 				20D83912289A80E700D91D05 /* Network */,
 				20D83913289A811600D91D05 /* UI */,
@@ -1866,13 +1869,10 @@
 		20D837BF289A7ACD00D91D05 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				2B6B3D712C38213600B041B5 /* JavaScript Support */,
 				0463E51027FCC1DF00806D5C /* AuroraEditorAPI.swift */,
 				20D837BE289A7ACD00D91D05 /* ExtensionsManager.swift */,
 				2B615ABB2BC865E400A5457F /* ExtensionViewStorage.swift */,
-				2B74A3F12C0F90B2002498F5 /* JSFetch.swift */,
-				2B74A3EF2C0F8FFA002498F5 /* JSPromise.swift */,
-				2B7C8CC52BC5B3160061DE0D /* JSSupport.swift */,
-				2BDE0F762BC8874800C20B85 /* JSTimerSupport.swift */,
 				20D837C2289A7ACD00D91D05 /* Plugin.swift */,
 				20D837C0289A7ACD00D91D05 /* PluginRelease.swift */,
 			);
@@ -2908,6 +2908,17 @@
 				2B3DAA4F2BFD24C500A7773D /* QLHighlighter.swift */,
 			);
 			path = AEquicklook;
+			sourceTree = "<group>";
+		};
+		2B6B3D712C38213600B041B5 /* JavaScript Support */ = {
+			isa = PBXGroup;
+			children = (
+				2B74A3F12C0F90B2002498F5 /* JSCFetch.swift */,
+				2B74A3EF2C0F8FFA002498F5 /* JSCPromise.swift */,
+				2B7C8CC52BC5B3160061DE0D /* JSSupport.swift */,
+				2BDE0F762BC8874800C20B85 /* JSCTimerSupport.swift */,
+			);
+			path = "JavaScript Support";
 			sourceTree = "<group>";
 		};
 		2BDFA90C28D10B9200980385 /* FileCreation */ = {
@@ -4011,6 +4022,7 @@
 				934D2F0A28C591FD0034E5C8 /* GeneralPreferencesViewSections.swift in Sources */,
 				2093CD31289AA089003A88DD /* Gist.swift in Sources */,
 				2093CD2A289AA084003A88DD /* GistRouter.swift in Sources */,
+				2B6B3D6D2C3820A100B041B5 /* ExtensionDocumentation.docc in Sources */,
 				2093CD35289AA089003A88DD /* Git.swift in Sources */,
 				2093CDB5289AA1A2003A88DD /* GitAccountItem.swift in Sources */,
 				2093CD15289AA054003A88DD /* GitClient.swift in Sources */,
@@ -4076,11 +4088,11 @@
 				2093CD24289AA084003A88DD /* IssueRouter.swift in Sources */,
 				20FACF6A2AB60E1C00B09012 /* IssueType.swift in Sources */,
 				2B04574B28E6FFE300024F2D /* ItalicThemeAttribute.swift in Sources */,
-				2B74A3F22C0F90B2002498F5 /* JSFetch.swift in Sources */,
+				2B74A3F22C0F90B2002498F5 /* JSCFetch.swift in Sources */,
 				2093CD4C289AA0A2003A88DD /* JSONPostRouter.swift in Sources */,
-				2B74A3F02C0F8FFA002498F5 /* JSPromise.swift in Sources */,
+				2B74A3F02C0F8FFA002498F5 /* JSCPromise.swift in Sources */,
 				2B7C8CC62BC5B3160061DE0D /* JSSupport.swift in Sources */,
-				2BDE0F772BC8874900C20B85 /* JSTimerSupport.swift in Sources */,
+				2BDE0F772BC8874900C20B85 /* JSCTimerSupport.swift in Sources */,
 				2B04574D28E6FFE300024F2D /* KernThemeAttribute.swift in Sources */,
 				20EBB50D280C383700F3A5DA /* LanguageType.swift in Sources */,
 				209D2F4A297BBE61005AB73C /* LicenseDetailView.swift in Sources */,

--- a/Aurora Editor.xcodeproj/project.pbxproj
+++ b/Aurora Editor.xcodeproj/project.pbxproj
@@ -1869,10 +1869,10 @@
 		20D837BF289A7ACD00D91D05 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				2B6B3D712C38213600B041B5 /* JavaScript Support */,
 				0463E51027FCC1DF00806D5C /* AuroraEditorAPI.swift */,
 				20D837BE289A7ACD00D91D05 /* ExtensionsManager.swift */,
 				2B615ABB2BC865E400A5457F /* ExtensionViewStorage.swift */,
+				2B6B3D712C38213600B041B5 /* JavaScript Support */,
 				20D837C2289A7ACD00D91D05 /* Plugin.swift */,
 				20D837C0289A7ACD00D91D05 /* PluginRelease.swift */,
 			);
@@ -2915,8 +2915,8 @@
 			children = (
 				2B74A3F12C0F90B2002498F5 /* JSCFetch.swift */,
 				2B74A3EF2C0F8FFA002498F5 /* JSCPromise.swift */,
-				2B7C8CC52BC5B3160061DE0D /* JSSupport.swift */,
 				2BDE0F762BC8874800C20B85 /* JSCTimerSupport.swift */,
+				2B7C8CC52BC5B3160061DE0D /* JSSupport.swift */,
 			);
 			path = "JavaScript Support";
 			sourceTree = "<group>";

--- a/Aurora EditorTests/AuroraJSSupportTests.swift
+++ b/Aurora EditorTests/AuroraJSSupportTests.swift
@@ -41,7 +41,7 @@ final class AuroraJSSupportTests: XCTestCase {
 
     /// Create a "custom" function, and run that custom function.
     func testJSAPIUsingRespondToCustomApi() {
-        guard let script = jsSupport?.evaluate(script: "function AECustomApiTest(v) { return v }"),
+        guard let script = jsSupport?.evaluate(script: "function AECustomApiTest(v) { return v.val }"),
               let value = jsSupport?.respond(
                 action: "AECustomApiTest",
                 parameters: ["val": "AECustomApiTest using respond()"]

--- a/AuroraEditor/Core/ExtensionSystem/ExtensionDocumentation.docc/ExtensionDocumentation.md
+++ b/AuroraEditor/Core/ExtensionSystem/ExtensionDocumentation.docc/ExtensionDocumentation.md
@@ -1,0 +1,91 @@
+# ``Aurora Editor`` Extension interface
+
+This is the (internal) documentation of the Aurora Extension Interface.
+
+## Overview
+
+...
+
+## Communication Between Aurora Editor and Extensions
+
+### Received actions for the extension
+- didOpen(file: String, contents: String)
+- didOpen(workspace: String, file: String, contents: String)
+- didSave(file: String)
+- didMoveCaret(row: Int, column: Int)
+- didActivateTab(file: String)
+- didDeactivateTab(file: String)
+- didToggleNavigatorPane(visible: Bool)
+- didToggleInspectorPane(visible: Bool)
+- registerCallback(callback: AuroraAPI -> Bool)
+- noop()
+
+### Actions to Aurora Editor
+- noop()
+- openSettings()
+- showNotification(title: String, message: String)
+- showWarning(title: String, message: String)
+- showError(title: String, message: String)
+- openSheet(view: View) // View can be SwiftUI, HTML, (JSON LATER)
+- openTab(view: View) // View can be SwiftUI, HTML, (JSON LATER)
+- openWindow(view: View) // View can be SwiftUI, HTML, (JSON LATER)
+
+## Demo Swift Extension
+
+```swift
+import Foundation
+import AEExtensionKit
+
+public class HelloWorldExtension: ExtensionInterface {
+    var api: ExtensionAPI
+    var AuroraAPI: AuroraAPI = { _, _ in }
+
+    init(api: ExtensionAPI) {
+        self.api = api
+        print("Hello from HelloWorldExtension: \(api)!")
+    }
+
+    public func register() -> ExtensionManifest {
+        return .init(
+            name: "HelloWorldExtension",
+            displayName: "HelloWorldExtension",
+            version: "1.0",
+            minAEVersion: "1.0"
+        )
+    }
+
+    public func respond(action: String, parameters: [String: Any]) -> Bool {
+        print("respond(action: String, parameters: [String: Any])", action, parameters)
+
+        if action == "registerCallback" {
+            if let api = parameters["callback"] as? AuroraAPI {
+                AuroraAPI = api
+            }
+        }
+
+        if action == "didOpen" {
+            if let workspace = parameters["workspace"] as? String,
+               let file = parameters["file"] as? String {
+                print("Opened workspace \(workspace) and file \(file)")
+            }
+        }
+
+        return true
+    }
+}
+
+@objc(HelloWorldBuilder)
+public class HelloWorldBuilder: ExtensionBuilder {
+    public override func build(withAPI api: ExtensionAPI) -> ExtensionInterface {
+        return HelloWorldExtension(api: api)
+    }
+}
+```
+
+## Demo JavaScript Extension
+
+```javascript
+function didOpen(parameters) {
+  AuroraEditor.log(parameters);
+}
+```

--- a/AuroraEditor/Core/ExtensionSystem/Models/JavaScript Support/JSCFetch.swift
+++ b/AuroraEditor/Core/ExtensionSystem/Models/JavaScript Support/JSCFetch.swift
@@ -11,9 +11,9 @@ import JavaScriptCore
 /// JavaScript `fetch` function
 ///
 /// - Note: Depends on JSPromise.
-class JSFetch {
+class JSCFetch {
     /// Shared instance so it will not be unloaded.
-    static let shared: JSFetch = .init()
+    static let shared: JSCFetch = .init()
 
     /// Register class into the current JavaScript Context.
     /// - Parameter jsContext: The current JavaScript context.
@@ -25,8 +25,8 @@ class JSFetch {
     }
 
     /// (Obj-C) The fetch function
-    let fetch: @convention(block) (String) -> JSPromise? = { link in
-        let promise = JSPromise()
+    let fetch: @convention(block) (String) -> JSCPromise? = { link in
+        let promise = JSCPromise()
         promise.timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { timer in
             timer.invalidate()
 

--- a/AuroraEditor/Core/ExtensionSystem/Models/JavaScript Support/JSCPromise.swift
+++ b/AuroraEditor/Core/ExtensionSystem/Models/JavaScript Support/JSCPromise.swift
@@ -12,18 +12,18 @@ import JavaScriptCore
     /// JavaScript `then` function
     /// - Parameter resolve: callback to resolve
     /// - Returns: promise
-    func then(_ resolve: JSValue) -> JSPromise?
+    func then(_ resolve: JSValue) -> JSCPromise?
 
     /// JavaScript `catch` function
     /// - Parameter resolve: callback to resolve
     /// - Returns: promise
-    func `catch`(_ reject: JSValue) -> JSPromise?
+    func `catch`(_ reject: JSValue) -> JSCPromise?
 }
 
 /// JavaScript Promise support
-class JSPromise: NSObject, JSPromiseExports {
+class JSCPromise: NSObject, JSPromiseExports {
     /// Shared instance so it will not be unloaded.
-    static let shared: JSPromise = .init()
+    static let shared: JSCPromise = .init()
 
     /// Resolve callback
     var resolve: JSValue?
@@ -32,7 +32,7 @@ class JSPromise: NSObject, JSPromiseExports {
     var reject: JSValue?
 
     /// Next promise
-    var next: JSPromise?
+    var next: JSCPromise?
 
     /// Timer
     var timer: Timer?
@@ -41,7 +41,7 @@ class JSPromise: NSObject, JSPromiseExports {
     /// - Parameter jsContext: The current JavaScript context.
     func registerInto(jsContext: JSContext) {
         jsContext.setObject(
-            JSPromise.self,
+            JSCPromise.self,
             forKeyedSubscript: "Promise" as (NSCopying & NSObjectProtocol)
         )
 
@@ -50,12 +50,12 @@ class JSPromise: NSObject, JSPromiseExports {
         """)
     }
 
-    func then(_ resolve: JSValue) -> JSPromise? {
+    func then(_ resolve: JSValue) -> JSCPromise? {
         // Setup the resolver (callback)
         self.resolve = resolve
 
         // Create another JSPromise
-        self.next = JSPromise()
+        self.next = JSCPromise()
 
         // Set the timer to 1s
         self.timer?.fireDate = Date(timeInterval: 1, since: Date())
@@ -70,12 +70,12 @@ class JSPromise: NSObject, JSPromiseExports {
         return self.next
     }
 
-    func `catch`(_ reject: JSValue) -> JSPromise? {
+    func `catch`(_ reject: JSValue) -> JSCPromise? {
         // Setup the reject (callback)
         self.reject = reject
 
         // Create another JSPromise
-        self.next = JSPromise()
+        self.next = JSCPromise()
 
         // Set the timer to 1s
         self.timer?.fireDate = Date(timeInterval: 1, since: Date())

--- a/AuroraEditor/Core/ExtensionSystem/Models/JavaScript Support/JSCTimerSupport.swift
+++ b/AuroraEditor/Core/ExtensionSystem/Models/JavaScript Support/JSCTimerSupport.swift
@@ -46,10 +46,10 @@ import JavaScriptCore
 /// - `setTimeout(callback, time)`
 /// - `clearTimeout(identifier)`
 /// - `setInterval(callback, time)`
-@objc class JSTimerSupport: NSObject, AEJSTimer {
+@objc class JSCTimerSupport: NSObject, AEJSTimer {
 
-    /// Shared instance of `JSTimerSupport`.
-    static let shared: JSTimerSupport = .init()
+    /// Shared instance of `JSCTimerSupport`.
+    static let shared: JSCTimerSupport = .init()
 
     /// Storage for the timers
     var timers = [String: Timer]()
@@ -58,7 +58,7 @@ import JavaScriptCore
     /// - Parameter jsContext: The current JavaScript context.
     func registerInto(jsContext: JSContext) {
         jsContext.setObject(
-            JSTimerSupport.shared,
+            JSCTimerSupport.shared,
             forKeyedSubscript: "AETimer" as (NSCopying & NSObjectProtocol)
         )
 


### PR DESCRIPTION
## Summary

Redone JavaScript Extension Calling

## Changes Made

Redone JavaScript Extension Calling

## TODO

Test if the `.docc` will be used in https://docs.auroraeditor.com as well.

## Motivation

Swift does not save the position of keys and values in an array which caused that JS extensions sometimes got incorrect values in their parameters.
To fix this extensions don't get separate parameters anymore, they get a JSON object which contains all the parameters and values.

## Testing
## Screenshots/GIFs

<img width="1110" alt="FCCD586A-7671-46AF-ADD0-F87F6308AA00" src="https://github.com/AuroraEditor/AuroraEditor/assets/1290461/cf5881b8-86cd-400c-b53f-46e09f5187f2">

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [x] Code has been tested and verified.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully.
- [x] Code follows the project's coding guidelines and style.
- [x] The branch is up-to-date with the latest changes from the main branch.
- [x] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): None

## Additional Notes

None