### PR TITLE
delete item to trash

### DIFF
--- a/AuroraEditor/Core/FileSystemClient/Model/FileItem/FileItemFileSystemFunctions.swift
+++ b/AuroraEditor/Core/FileSystemClient/Model/FileItem/FileItemFileSystemFunctions.swift
@@ -104,7 +104,10 @@ extension FileItem {
         if deleteConfirmation.runModal() == .alertFirstButtonReturn { // "Delete" button
             if FileItem.fileManger.fileExists(atPath: self.url.path) {
                 do {
-                    try FileItem.fileManger.removeItem(at: self.url)
+                    try FileItem.fileManger.trashItem(
+                        at: self.url,
+                        resultingItemURL: nil
+                    )
                 } catch {
                     fatalError(error.localizedDescription)
                 }

--- a/AuroraEditor/Core/FileSystemClient/Model/FileItem/FileItemFileSystemFunctions.swift
+++ b/AuroraEditor/Core/FileSystemClient/Model/FileItem/FileItemFileSystemFunctions.swift
@@ -104,7 +104,6 @@ extension FileItem {
         if deleteConfirmation.runModal() == .alertFirstButtonReturn { // "Delete" button
             if FileItem.fileManger.fileExists(atPath: self.url.path) {
                 do {
-                    logger.info("Should trash item \(self.url)")
                     try FileItem.fileManger.trashItem(
                         at: self.url,
                         resultingItemURL: nil

--- a/AuroraEditor/Core/FileSystemClient/Model/FileItem/FileItemFileSystemFunctions.swift
+++ b/AuroraEditor/Core/FileSystemClient/Model/FileItem/FileItemFileSystemFunctions.swift
@@ -104,6 +104,7 @@ extension FileItem {
         if deleteConfirmation.runModal() == .alertFirstButtonReturn { // "Delete" button
             if FileItem.fileManger.fileExists(atPath: self.url.path) {
                 do {
+                    logger.info("Should trash item \(self.url)")
                     try FileItem.fileManger.trashItem(
                         at: self.url,
                         resultingItemURL: nil

--- a/AuroraEditor/Core/NavigatorSidebar/Model/ProjectNavigator/ProjectNavigatorMenu.swift
+++ b/AuroraEditor/Core/NavigatorSidebar/Model/ProjectNavigator/ProjectNavigatorMenu.swift
@@ -281,7 +281,10 @@ final class ProjectNavigatorMenu: NSMenu {
                         workspace?.closeTab(item: item.tabID)
                     }
                     // TODO: When file gets deleted we should update the Project Navigator
-                    try fileManger.removeItem(at: item.url)
+                    try FileItem.fileManger.trashItem(
+                        at: item.url,
+                        resultingItemURL: nil
+                    )
                 } catch {
                     fatalError(error.localizedDescription)
                 }


### PR DESCRIPTION
## Summary

delete item to trash instead of deleting it directly, this takes care that a user which deletes their files unintended can get it back using the "Trash".

## Changes Made

Move to trash instead of delete.

## TODO

None.

## Motivation

this takes care that a user which deletes their files unintended can get it back using the "Trash".

## Testing

None

## Screenshots/GIFs

<img width="787" alt="image" src="https://github.com/AuroraEditor/AuroraEditor/assets/1290461/c77722f5-e0ca-4c87-a5ed-54b9950b4d6f">

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [x] Code has been tested and verified.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully.
- [x] Code follows the project's coding guidelines and style.
- [x] The branch is up-to-date with the latest changes from the main branch.
- [x] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): None

## Additional Notes

None